### PR TITLE
Fix package name for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ llm := goai.NewLLMRequest(ai.NewRequestConfig(
 ), provider)
 
 // Generate response
-response, err := llm.Generate([]ai.LLMMessage{
+response, err := llm.Generate([]goai.LLMMessage{
     {Role: goai.UserRole, Text: "Explain quantum computing"},
 })
 ```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -31,7 +31,7 @@ config := goai.NewRequestConfig(
 llm := goai.NewLLMRequest(config, provider)
 
 // Generate response
-response, err := llm.Generate([]ai.LLMMessage{
+response, err := llm.Generate([]goai.LLMMessage{
     {Role: goai.SystemRole, Text: "You are a helpful assistant"},
     {Role: goai.UserRole, Text: "Hello"},
 })

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ config := goai.NewRequestConfig(ai.WithMaxToken(1000))
 llm := goai.NewLLMRequest(config, provider)
 
 // Generate response
-response, err := llm.Generate([]ai.LLMMessage{
+response, err := llm.Generate([]goai.LLMMessage{
     {Role: goai.UserRole, Text: "Hello"},
 })
 ```

--- a/docs/llm/anthropic.md
+++ b/docs/llm/anthropic.md
@@ -16,7 +16,7 @@ provider := goai.NewAnthropicLLMProvider(ai.AnthropicProviderConfig{
 ## Message Handling
 
 ```go
-messages := []ai.LLMMessage{
+messages := []goai.LLMMessage{
     {Role: goai.SystemRole, Text: "You are a helpful assistant"},
     {Role: goai.UserRole, Text: "Hello"},
     {Role: goai.AssistantRole, Text: "Hi there!"},

--- a/docs/llm/bedrock.md
+++ b/docs/llm/bedrock.md
@@ -13,7 +13,7 @@ provider := goai.NewBedrockLLMProvider(ai.BedrockProviderConfig{
 ## Message Handling
 
 ```go
-messages := []ai.LLMMessage{
+messages := []goai.LLMMessage{
     {Role: goai.UserRole, Text: "Hello"},
     {Role: goai.AssistantRole, Text: "Hi there!"},
 }

--- a/docs/llm/index.md
+++ b/docs/llm/index.md
@@ -77,7 +77,7 @@ type LLMMessage struct {
 ```go
 llm := goai.NewLLMRequest(config, provider)
 
-response, err := llm.Generate([]ai.LLMMessage{
+response, err := llm.Generate([]goai.LLMMessage{
     {Role: goai.SystemRole, Text: "You are a helpful assistant"},
     {Role: goai.UserRole, Text: "Hello"},
 })
@@ -119,7 +119,7 @@ template := &ai.LLMPromptTemplate{
 }
 
 promptText, err := template.Parse()
-messages := []ai.LLMMessage{
+messages := []goai.LLMMessage{
     {Role: goai.UserRole, Text: promptText},
 }
 ```

--- a/docs/llm/openai.md
+++ b/docs/llm/openai.md
@@ -19,7 +19,7 @@ provider := goai.NewOpenAILLMProvider(ai.OpenAIProviderConfig{
 ## Message Handling
 
 ```go
-messages := []ai.LLMMessage{
+messages := []goai.LLMMessage{
     {Role: goai.SystemRole, Text: "You are a helpful assistant"},
     {Role: goai.UserRole, Text: "Hello"},
 }

--- a/docs/prompt_template.md
+++ b/docs/prompt_template.md
@@ -41,7 +41,7 @@ if err != nil {
     return err
 }
 
-messages := []ai.LLMMessage{
+messages := []goai.LLMMessage{
     {Role: goai.UserRole, Text: promptText},
 }
 ```

--- a/llm.go
+++ b/llm.go
@@ -41,7 +41,7 @@ func NewLLMRequest(config LLMRequestConfig, provider LLMProvider) *LLMRequest {
 //
 // Example usage:
 //
-//	messages := []ai.LLMMessage{
+//	messages := []goai.LLMMessage{
 //	    {Role: goai.SystemRole, Text: "You are a helpful assistant"},
 //	    {Role: goai.UserRole, Text: "What is the capital of France?"},
 //	}

--- a/llm_provider_openai.go
+++ b/llm_provider_openai.go
@@ -85,7 +85,7 @@ func (p *OpenAILLMProvider) createCompletionParams(messages []openai.ChatComplet
 //
 // Example usage:
 //
-//	messages := []ai.LLMMessage{
+//	messages := []goai.LLMMessage{
 //	    {Role: "system", Text: "You are a helpful assistant"},
 //	    {Role: "user", Text: "What is the capital of France?"},
 //	}


### PR DESCRIPTION
This pull request includes multiple changes to update the usage of message types across various documentation files and code comments. The changes replace instances of `ai.LLMMessage` with `goai.LLMMessage` to ensure consistency with the updated library.

Updates to message types:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R53): Changed `ai.LLMMessage` to `goai.LLMMessage` in the `llm.Generate` function call.
* [`docs/getting_started.md`](diffhunk://#diff-7627439dcd69d95a42bb123ac4cfb7682f86da5d6aee037206d9857459906243L34-R34): Updated message type from `ai.LLMMessage` to `goai.LLMMessage` in the `llm.Generate` function call.
* [`docs/index.md`](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L44-R44): Replaced `ai.LLMMessage` with `goai.LLMMessage` in multiple instances for response generation. [[1]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L44-R44) [[2]](diffhunk://#diff-de22f57e9dc9407fc8e05b1341d59f88c08ff4f289943eaa954dbe767a8ad323L80-R80) [[3]](diffhunk://#diff-de22f57e9dc9407fc8e05b1341d59f88c08ff4f289943eaa954dbe767a8ad323L122-R122)
* `docs/llm/anthropic.md`, `docs/llm/bedrock.md`, `docs/llm/openai.md`: Updated message type from `ai.LLMMessage` to `goai.LLMMessage` in message handling examples. [[1]](diffhunk://#diff-01bee91b9833ab363ee48145204a1dcc825c996b1e885e836c11e18755bdeb59L19-R19) [[2]](diffhunk://#diff-93ee822ded426c22329415506b571199cc7576d56713adb05dd190f86a9b8182L16-R16) [[3]](diffhunk://#diff-38259fbfc6d12579d742fcc49cc77c80f725a08659eac306d48bcf0e118caad7L22-R22)
* [`docs/prompt_template.md`](diffhunk://#diff-0a5883acbd4b204df32358df5a36e146a7430148d28e10e820266b599d051a7aL44-R44): Changed `ai.LLMMessage` to `goai.LLMMessage` in the message handling example.

Updates to code comments:

* `llm.go`, `llm_provider_openai.go`: Updated code comments to reflect the change from `ai.LLMMessage` to `goai.LLMMessage`. [[1]](diffhunk://#diff-8f25989fee211f872264334354217c9b60c1360228f1890635844d0aacfcbf5aL44-R44) [[2]](diffhunk://#diff-19bdea5cc92c5bad6ea9868bc31b918edd9fbd453ce549dc93448d2ceaaaf9baL88-R88)