### PR TITLE
Implement tool calling and prompt handling for MCP client

### DIFF
--- a/docs/llm.md
+++ b/docs/llm.md
@@ -105,6 +105,16 @@ err := toolsProvider.AddTools(tools)
 ```
 <!-- markdownlint-enable -->
 
+If you want to integrate MCP (Model Context Protocol) server with your tool, you can use the MCP Client.
+Details about how to use MCP Client can be found [here](mcp.md#client)
+
+```go
+//mcpClient := 
+err := toolsProvider.AddMCPClient(mcpClient)
+```
+
+**Note: If you provide both tools and MCP client, the attached tools will be used for tool calling.**
+
 ### Using Tools with LLM Provider
 
 <!-- markdownlint-disable -->

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -235,39 +235,40 @@ func main() {
 package main
 
 import (
-    "fmt"
-    "log"
-    "os"
-    "time"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
 
-    "github.com/shaharia-lab/goai/mcp"
+	"github.com/shaharia-lab/goai/mcp"
 )
 
 func main() {
-    sseConfig := mcp.ClientConfig{
-        ClientName:    "MySSEClient",
-        ClientVersion: "1.0.0",
-        Logger:        log.New(os.Stdout, "[SSE] ", log.LstdFlags),
-        RetryDelay:    5 * time.Second,
-        MaxRetries:    3,
-        SSE: mcp.SSEConfig{
-            URL: "http://localhost:8080/events", // Replace with your SSE endpoint
-        },
-    }
+	sseConfig := mcp.ClientConfig{
+		ClientName:    "MySSEClient",
+		ClientVersion: "1.0.0",
+		Logger:        log.New(os.Stdout, "[SSE] ", log.LstdFlags),
+		RetryDelay:    5 * time.Second,
+		MaxRetries:    3,
+		SSE: mcp.SSEConfig{
+			URL: "http://localhost:8080/events", // Replace with your SSE endpoint
+		},
+	}
+	ctx := context.Background()
+	sseTransport := mcp.NewSSETransport()
+	sseClient := mcp.NewClient(sseTransport, sseConfig)
 
-    sseTransport := mcp.NewSSETransport()
-    sseClient := mcp.NewClient(sseTransport, sseConfig)
+	if err := sseClient.Connect(ctx); err != nil {
+		log.Fatalf("SSE Client failed to connect: %v", err)
+	}
+	defer sseClient.Close(ctx)
 
-    if err := sseClient.Connect(); err != nil {
-        log.Fatalf("SSE Client failed to connect: %v", err)
-    }
-    defer sseClient.Close()
-
-    tools, err := sseClient.ListTools()
-    if err != nil {
-        log.Fatalf("Failed to list tools (SSE): %v", err)
-    }
-    fmt.Printf("SSE Tools: %+v\n", tools)
+	tools, err := sseClient.ListTools(ctx)
+	if err != nil {
+		log.Fatalf("Failed to list tools (SSE): %v", err)
+	}
+	fmt.Printf("SSE Tools: %+v\n", tools)
 }
 ```
 

--- a/mcp/server_base.go
+++ b/mcp/server_base.go
@@ -426,7 +426,7 @@ func (s *BaseServer) handleToolsList(clientID string, request *Request) {
 		return
 	}
 
-	s.sendResp(clientID, request.ID, s.ListTools(params.Cursor, 1), nil)
+	s.sendResp(clientID, request.ID, s.ListTools(params.Cursor, 100), nil)
 }
 
 func (s *BaseServer) handleToolsCall(clientID string, request *Request) {
@@ -448,7 +448,7 @@ func (s *BaseServer) handleToolsCall(clientID string, request *Request) {
 // ListPrompts returns a list of all available prompts, with optional pagination
 func (s *BaseServer) ListPrompts(cursor string, limit int) ListPromptsResult {
 	if limit <= 0 {
-		limit = 50 // Default limit
+		limit = 50
 	}
 
 	// Get sorted list of prompt names
@@ -502,7 +502,7 @@ func (s *BaseServer) handlePromptsList(clientID string, request *Request) {
 		return
 	}
 
-	result := s.ListPrompts(params.Cursor, 0)
+	result := s.ListPrompts(params.Cursor, 100)
 	s.sendResp(clientID, request.ID, result, nil)
 }
 

--- a/tools_provider.go
+++ b/tools_provider.go
@@ -64,7 +64,7 @@ func (p *ToolsProvider) ExecuteTool(ctx context.Context, params mcp.CallToolPara
 	}
 
 	if p.mcpClient.IsInitialized() {
-		return mcp.CallToolResult{}, fmt.Errorf("MCP client does not support tool execution yet")
+		return p.mcpClient.CallTool(ctx, params)
 	}
 
 	return mcp.CallToolResult{}, fmt.Errorf("tool not found: %s", params.Name)


### PR DESCRIPTION
This pull request includes several changes to integrate the MCP (Model Context Protocol) client with the existing tools infrastructure and improve the handling of tool and prompt requests. The most important changes include updates to the documentation, modifications to the `mcp/client.go` and `mcp/server_base.go` files, and enhancements to the `tools_provider.go` file.

Documentation updates:

* Added instructions for integrating the MCP client with tools in `docs/llm.md`.
* Updated `docs/mcp.md` to include context handling in the main function. [[1]](diffhunk://#diff-540fac6ea007bc938b77f99fe1f0766cf1ab7628ffed1d2830327fb2dab88c28R238) [[2]](diffhunk://#diff-540fac6ea007bc938b77f99fe1f0766cf1ab7628ffed1d2830327fb2dab88c28L257-R267)

MCP client updates:

* Added new methods `CallTool`, `ListPrompts`, and `GetPrompt` in `mcp/client.go` to handle tool and prompt requests with context.

Server updates:

* Modified `handleToolsList` and `handlePromptsList` methods in `mcp/server_base.go` to increase the limit for list requests to 100. [[1]](diffhunk://#diff-09be4d1ba8654a2b99762a16318bb749ce0f7afbb02dc32bfc717c7d090c6b5eL429-R429) [[2]](diffhunk://#diff-09be4d1ba8654a2b99762a16318bb749ce0f7afbb02dc32bfc717c7d090c6b5eL505-R505)

Tools provider updates:

* Updated `ExecuteTool` method in `tools_provider.go` to support tool execution via the MCP client.