### PR TITLE
Add context parameter to server request handlers

### DIFF
--- a/mcp/server_base_test.go
+++ b/mcp/server_base_test.go
@@ -127,7 +127,7 @@ func TestListTools(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := baseServer.ListTools(tt.cursor, tt.limit)
+			result := baseServer.ListTools(context.Background(), tt.cursor, tt.limit)
 
 			assert.Len(t, result.Tools, len(tt.wantTools),
 				"Expected %d tools, got %d", len(tt.wantTools), len(result.Tools))

--- a/mcp/server_sse.go
+++ b/mcp/server_sse.go
@@ -280,7 +280,7 @@ func (s *SSEServer) handleClientMessage(w http.ResponseWriter, r *http.Request) 
 			s.sendError(clientID, request.ID, -32000, "Server not initialized", nil)
 			return
 		}
-		s.handleRequest(clientID, &request)
+		s.handleRequest(r.Context(), clientID, &request)
 		return
 	}
 
@@ -298,7 +298,7 @@ func (s *SSEServer) handleClientMessage(w http.ResponseWriter, r *http.Request) 
 			s.logger.Printf("Received notification before 'initialized': %s", notification.Method)
 			return
 		}
-		s.handleNotification(clientID, &notification)
+		s.handleNotification(r.Context(), clientID, &notification)
 		return
 	}
 

--- a/mcp/server_stdio.go
+++ b/mcp/server_stdio.go
@@ -144,7 +144,7 @@ func (s *StdIOServer) Run(ctx context.Context) error {
 						s.sendError("", request.ID, -32000, "Server not initialized", nil) // Empty clientID
 						continue
 					}
-					s.handleRequest("", &request) // StdIO has no persistent client ID, so we pass an empty string.
+					s.handleRequest(ctx, "", &request) // StdIO has no persistent client ID, so we pass an empty string.
 					continue
 				}
 
@@ -156,7 +156,7 @@ func (s *StdIOServer) Run(ctx context.Context) error {
 						s.logger.Printf("Received notification before 'initialized': %s", notification.Method)
 						continue
 					}
-					s.handleNotification("", &notification) // Empty clientID.
+					s.handleNotification(nil, "", &notification) // Empty clientID.
 					continue
 				}
 

--- a/mcp/server_stdio_test.go
+++ b/mcp/server_stdio_test.go
@@ -460,7 +460,7 @@ func TestStdIOServerRequests(t *testing.T) {
 			}
 
 			// Handle the request
-			server.handleRequest("test-client", &request)
+			server.handleRequest(context.Background(), "test-client", &request)
 
 			// Get output and clean it up (remove newline)
 			got := strings.TrimSpace(out.String())
@@ -531,7 +531,7 @@ func TestStdIOServerRequestsWithToolsMethod(t *testing.T) {
 			}
 
 			// Handle the request
-			server.handleRequest("test-client", &request)
+			server.handleRequest(context.Background(), "test-client", &request)
 
 			// Get output and clean it up (remove newline)
 			got := strings.TrimSpace(out.String())


### PR DESCRIPTION
This pull request introduces changes to the `mcp` package to ensure that context is passed through various server methods. The primary goal is to support better context management and potential cancellation of operations. The most important changes include modifying the `handleRequest` and `handleNotification` methods to accept a `context.Context` parameter and updating corresponding method calls.

### Context management improvements:

* [`mcp/server_base.go`](diffhunk://#diff-09be4d1ba8654a2b99762a16318bb749ce0f7afbb02dc32bfc717c7d090c6b5eL235-R256): Updated `handleRequest` and `handleNotification` methods to accept a `context.Context` parameter and propagated this change to all methods that `handleRequest` calls. [[1]](diffhunk://#diff-09be4d1ba8654a2b99762a16318bb749ce0f7afbb02dc32bfc717c7d090c6b5eL235-R256) [[2]](diffhunk://#diff-09be4d1ba8654a2b99762a16318bb749ce0f7afbb02dc32bfc717c7d090c6b5eL575-R578)
* [`mcp/server_sse.go`](diffhunk://#diff-502a521967c72a998319f0ec0180cbf7ce3c46b493af6b08d8d7f68a8c89fe2eL283-R283): Modified `handleClientMessage` to pass the request context to `handleRequest` and `handleNotification`. [[1]](diffhunk://#diff-502a521967c72a998319f0ec0180cbf7ce3c46b493af6b08d8d7f68a8c89fe2eL283-R283) [[2]](diffhunk://#diff-502a521967c72a998319f0ec0180cbf7ce3c46b493af6b08d8d7f68a8c89fe2eL301-R301)
* [`mcp/server_stdio.go`](diffhunk://#diff-caa33f9792087c37e1ba3f8ac23f428fd8b82385171bafe60ab6662bef1d7a75L147-R147): Updated `Run` method to pass the context to `handleRequest` and `handleNotification`. [[1]](diffhunk://#diff-caa33f9792087c37e1ba3f8ac23f428fd8b82385171bafe60ab6662bef1d7a75L147-R147) [[2]](diffhunk://#diff-caa33f9792087c37e1ba3f8ac23f428fd8b82385171bafe60ab6662bef1d7a75L159-R159)

### Test updates:

* [`mcp/server_base_test.go`](diffhunk://#diff-344dd31fd01184ff4865bc7045efd045f5cb1cccfb0478d91a04d39f6b8bec4dL130-R130): Adjusted tests to pass a `context.Context` to `ListTools`.
* [`mcp/server_stdio_test.go`](diffhunk://#diff-1590192765d357863edd0e5dec3ce64d619d3fa14e30997078d55821484b7d3fL463-R463): Updated tests to pass a `context.Context` to `handleRequest`. [[1]](diffhunk://#diff-1590192765d357863edd0e5dec3ce64d619d3fa14e30997078d55821484b7d3fL463-R463) [[2]](diffhunk://#diff-1590192765d357863edd0e5dec3ce64d619d3fa14e30997078d55821484b7d3fL534-R534)This commit updates server request and notification handlers to include a context parameter. This change ensures proper context propagation and improves support for request cancellation and deadlines. Test cases are also updated to match the new method signatures.