### PR TITLE
Add OpenTelemetry tracing to AnthropicLLMProvider responses

### DIFF
--- a/llm.go
+++ b/llm.go
@@ -1,6 +1,8 @@
 package goai
 
-import "context"
+import (
+	"context"
+)
 
 // LLMRequest handles the configuration and execution of LLM requests.
 // It provides a consistent interface for interacting with different LLM providers.

--- a/llm_provider_anthropic.go
+++ b/llm_provider_anthropic.go
@@ -3,11 +3,12 @@ package goai
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/shaharia-lab/goai/observability"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	"strings"
-	"time"
 
 	"github.com/shaharia-lab/goai/mcp"
 

--- a/tools_provider.go
+++ b/tools_provider.go
@@ -3,11 +3,12 @@ package goai
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/shaharia-lab/goai/observability"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
-	"time"
 
 	"github.com/shaharia-lab/goai/mcp"
 )

--- a/tools_provider.go
+++ b/tools_provider.go
@@ -3,6 +3,11 @@ package goai
 import (
 	"context"
 	"fmt"
+	"github.com/shaharia-lab/goai/observability"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"time"
 
 	"github.com/shaharia-lab/goai/mcp"
 )
@@ -53,19 +58,104 @@ func (p *ToolsProvider) ListTools(ctx context.Context) ([]mcp.Tool, error) {
 
 // ExecuteTool executes a tool with the specified ID, name, and parameters.
 func (p *ToolsProvider) ExecuteTool(ctx context.Context, params mcp.CallToolParams) (mcp.CallToolResult, error) {
+	ctx, span := observability.StartSpan(ctx, "ToolsProvider.ExecuteTool")
+	span.SetAttributes(
+		attribute.String("tool_name", params.Name),
+		attribute.String("arguments", string(params.Arguments)),
+	)
+	defer span.End()
+
+	var err error
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+	}()
+
+	startTime := time.Now()
+
+	// Record initial state
 	if p.mcpClient.IsInitialized() == false && len(p.toolsList) == 0 {
-		return mcp.CallToolResult{}, fmt.Errorf("no tools available")
+		err = fmt.Errorf("no tools available")
+		return mcp.CallToolResult{}, err
 	}
 
-	for _, tool := range p.toolsList {
+	// Try local tools first
+	span.AddEvent("CheckingLocalTools",
+		trace.WithAttributes(attribute.Int("local_tools_count", len(p.toolsList))))
+
+	for i, tool := range p.toolsList {
 		if tool.Name == params.Name {
-			return tool.Handler(ctx, params)
+			span.AddEvent("FoundLocalTool",
+				trace.WithAttributes(attribute.Int("tool_index", i)))
+
+			execCtx, execSpan := observability.StartSpan(ctx, "ExecuteTool.Handler")
+			execSpan.SetAttributes(
+				attribute.String("tool_name", tool.Name),
+			)
+
+			result, execErr := tool.Handler(execCtx, params)
+
+			if execErr != nil {
+				execSpan.RecordError(execErr)
+				execSpan.SetStatus(codes.Error, execErr.Error())
+			} else {
+				execSpan.SetAttributes(
+					attribute.Bool("is_error", result.IsError),
+					attribute.Int("content_length", len(result.Content)),
+				)
+			}
+			execSpan.End()
+
+			// Capture execution time in parent span
+			span.SetAttributes(
+				attribute.Float64("execution_time_ms", float64(time.Since(startTime).Milliseconds())),
+				attribute.Bool("is_local_tool", true),
+			)
+
+			return result, execErr
 		}
 	}
 
+	// Try remote MCP client if no local tool found
 	if p.mcpClient.IsInitialized() {
-		return p.mcpClient.CallTool(ctx, params)
+		span.AddEvent("FallingBackToMCPClient")
+
+		// Create child span for MCP client call
+		mcpCtx, mcpSpan := observability.StartSpan(ctx, "ToolsProvider.ExecuteTool_MCPClient")
+		mcpSpan.SetAttributes(
+			attribute.String("tool_name", params.Name),
+		)
+
+		result, mcpErr := p.mcpClient.CallTool(mcpCtx, params)
+
+		if mcpErr != nil {
+			mcpSpan.RecordError(mcpErr)
+			mcpSpan.SetStatus(codes.Error, mcpErr.Error())
+		} else {
+			mcpSpan.SetAttributes(
+				attribute.Bool("is_error", result.IsError),
+				attribute.Int("content_length", len(result.Content)),
+			)
+		}
+		mcpSpan.End()
+
+		// Capture execution time in parent span
+		span.SetAttributes(
+			attribute.Float64("execution_time_ms", float64(time.Since(startTime).Milliseconds())),
+			attribute.Bool("is_mcp_tool", true),
+		)
+
+		return result, mcpErr
 	}
 
-	return mcp.CallToolResult{}, fmt.Errorf("tool not found: %s", params.Name)
+	// No tool found
+	err = fmt.Errorf("tool not found: %s", params.Name)
+	span.SetAttributes(
+		attribute.Float64("execution_time_ms", float64(time.Since(startTime).Milliseconds())),
+		attribute.Bool("tool_found", false),
+	)
+
+	return mcp.CallToolResult{}, err
 }


### PR DESCRIPTION
This pull request introduces observability enhancements to the `goai` package by integrating OpenTelemetry for better tracing and error handling. The changes primarily focus on adding spans and attributes to key functions within the `AnthropicLLMProvider` and `ToolsProvider` classes.

Observability enhancements:

* [`llm_provider_anthropic.go`](diffhunk://#diff-f9087be89828f09a9531b695f2e8b8a6df1a67d2b2e83e4d2784ee223f4918e7R6-R8): Integrated OpenTelemetry spans and attributes in the `GetResponse` method to trace the execution flow and capture relevant metrics, such as model details, token counts, and tool execution results. [[1]](diffhunk://#diff-f9087be89828f09a9531b695f2e8b8a6df1a67d2b2e83e4d2784ee223f4918e7R6-R8) [[2]](diffhunk://#diff-f9087be89828f09a9531b695f2e8b8a6df1a67d2b2e83e4d2784ee223f4918e7R101-R119) [[3]](diffhunk://#diff-f9087be89828f09a9531b695f2e8b8a6df1a67d2b2e83e4d2784ee223f4918e7R144) [[4]](diffhunk://#diff-f9087be89828f09a9531b695f2e8b8a6df1a67d2b2e83e4d2784ee223f4918e7R155-R185) [[5]](diffhunk://#diff-f9087be89828f09a9531b695f2e8b8a6df1a67d2b2e83e4d2784ee223f4918e7L158-R218) [[6]](diffhunk://#diff-f9087be89828f09a9531b695f2e8b8a6df1a67d2b2e83e4d2784ee223f4918e7R233-R237) [[7]](diffhunk://#diff-f9087be89828f09a9531b695f2e8b8a6df1a67d2b2e83e4d2784ee223f4918e7R248-R254)
* [`tools_provider.go`](diffhunk://#diff-a2ca8a83e16290f5e1075cd4ffc2436d47e6e80435f4ea78c5716243b63d7bbfR6-R10): Added OpenTelemetry spans and attributes in the `ExecuteTool` method to monitor tool execution, including local and remote tool handling, and capture execution times and errors. [[1]](diffhunk://#diff-a2ca8a83e16290f5e1075cd4ffc2436d47e6e80435f4ea78c5716243b63d7bbfR6-R10) [[2]](diffhunk://#diff-a2ca8a83e16290f5e1075cd4ffc2436d47e6e80435f4ea78c5716243b63d7bbfR61-R160)

Minor code improvements:

* [`llm.go`](diffhunk://#diff-8f25989fee211f872264334354217c9b60c1360228f1890635844d0aacfcbf5aL3-R5): Updated import statements to use a multi-line format for better readability.