### PR TITLE
Improve tracing and few re-factoring

### DIFF
--- a/llm.go
+++ b/llm.go
@@ -31,6 +31,12 @@ type LLMRequest struct {
 //	// Create LLM request client
 //	llm := goai.NewLLMRequest(config, provider)
 func NewLLMRequest(config LLMRequestConfig, provider LLMProvider) *LLMRequest {
+	if !config.DisableTracing {
+		if _, isAlreadyTraced := provider.(*TracingLLMProvider); !isAlreadyTraced {
+			provider = NewTracingLLMProvider(provider)
+		}
+	}
+
 	return &LLMRequest{
 		requestConfig: config,
 		provider:      NewTracingLLMProvider(provider),

--- a/llm.go
+++ b/llm.go
@@ -33,7 +33,7 @@ type LLMRequest struct {
 func NewLLMRequest(config LLMRequestConfig, provider LLMProvider) *LLMRequest {
 	return &LLMRequest{
 		requestConfig: config,
-		provider:      provider,
+		provider:      NewTracingLLMProvider(provider),
 	}
 }
 

--- a/llm_provider_anthropic.go
+++ b/llm_provider_anthropic.go
@@ -115,7 +115,7 @@ func (p *AnthropicLLMProvider) GetResponse(ctx context.Context, messages []LLMMe
 
 	// Prepare tools if registry exists
 	var tools []anthropic.ToolParam
-	mcpTools, err := config.toolsProvider.ListTools(ctx)
+	mcpTools, err := config.toolsProvider.ListTools(ctx, config.AllowedTools)
 	if err != nil {
 		return LLMResponse{}, fmt.Errorf("error listing tools: %w", err)
 	}

--- a/llm_provider_openai.go
+++ b/llm_provider_openai.go
@@ -106,7 +106,7 @@ func (p *OpenAILLMProvider) GetResponse(ctx context.Context, messages []LLMMessa
 
 	var tools []openai.ChatCompletionToolParam
 
-	toolLists, err := config.toolsProvider.ListTools(ctx)
+	toolLists, err := config.toolsProvider.ListTools(ctx, config.AllowedTools)
 	if err != nil {
 		return LLMResponse{}, fmt.Errorf("failed to list tools: %w", err)
 	}

--- a/tracing_llm_provider.go
+++ b/tracing_llm_provider.go
@@ -1,0 +1,95 @@
+package goai
+
+import (
+	"context"
+	"github.com/shaharia-lab/goai/observability"
+	"go.opentelemetry.io/otel/attribute"
+	"time"
+)
+
+// TracingLLMProvider implements the decorator pattern for tracing
+type TracingLLMProvider struct {
+	provider LLMProvider
+}
+
+// NewTracingLLMProvider creates a new tracing decorator for any LLMProvider
+func NewTracingLLMProvider(provider LLMProvider) *TracingLLMProvider {
+	return &TracingLLMProvider{
+		provider: provider,
+	}
+}
+
+// GetResponse implements LLMProvider interface with added tracing
+func (t *TracingLLMProvider) GetResponse(ctx context.Context, messages []LLMMessage, config LLMRequestConfig) (LLMResponse, error) {
+	ctx, span := observability.StartSpan(ctx, "LLMProvider.GetResponse")
+	defer span.End()
+
+	startTime := time.Now()
+
+	// Call the underlying provider
+	response, err := t.provider.GetResponse(ctx, messages, config)
+
+	if err != nil {
+		span.RecordError(err)
+		return LLMResponse{}, err
+	}
+
+	span.SetAttributes(
+		attribute.Int("total_input_token", response.TotalInputToken),
+		attribute.Int("total_output_token", response.TotalOutputToken),
+		attribute.Int("message_count", len(messages)),
+		attribute.Float64("completion_time", time.Since(startTime).Seconds()),
+		attribute.Int64("max_token", config.MaxToken),
+		attribute.Float64("temperature", config.Temperature),
+		attribute.Float64("top_p", config.TopP),
+		attribute.Int64("top_k", config.TopK),
+	)
+
+	return response, nil
+}
+
+// GetStreamingResponse implements LLMProvider interface with added tracing
+func (t *TracingLLMProvider) GetStreamingResponse(ctx context.Context, messages []LLMMessage, config LLMRequestConfig) (<-chan StreamingLLMResponse, error) {
+	ctx, span := observability.StartSpan(ctx, "LLMProvider.GetStreamingResponse")
+
+	startTime := time.Now()
+
+	// Get the original stream
+	originalStream, err := t.provider.GetStreamingResponse(ctx, messages, config)
+	if err != nil {
+		span.RecordError(err)
+		span.End()
+		return nil, err
+	}
+
+	tracedStream := make(chan StreamingLLMResponse)
+
+	go func() {
+		defer span.End()
+		defer close(tracedStream)
+
+		var totalTokens int
+
+		for response := range originalStream {
+			if response.Error != nil {
+				span.RecordError(response.Error)
+				tracedStream <- response
+				return
+			}
+
+			totalTokens += len(response.Text)
+			tracedStream <- response
+
+			if response.Done {
+				span.SetAttributes(
+					attribute.Int("total_tokens", totalTokens),
+					attribute.Float64("total_streaming_time", time.Since(startTime).Seconds()),
+					attribute.Int("message_count", len(messages)),
+				)
+				return
+			}
+		}
+	}()
+
+	return tracedStream, nil
+}

--- a/types.go
+++ b/types.go
@@ -37,6 +37,7 @@ type LLMRequestConfig struct {
 	Temperature    float64
 	TopK           int64
 	DisableTracing bool
+	AllowedTools   []string
 }
 
 func WithTracingDisabled() RequestOption {
@@ -100,6 +101,12 @@ func WithTopK(topK int64) RequestOption {
 func UseToolsProvider(provider *ToolsProvider) RequestOption {
 	return func(c *LLMRequestConfig) {
 		c.toolsProvider = provider
+	}
+}
+
+func WithAllowedTools(allowedTools []string) RequestOption {
+	return func(c *LLMRequestConfig) {
+		c.AllowedTools = allowedTools
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -31,11 +31,18 @@ var DefaultConfig = LLMRequestConfig{
 
 // LLMRequestConfig defines configuration parameters for LLM requests.
 type LLMRequestConfig struct {
-	toolsProvider *ToolsProvider
-	MaxToken      int64
-	TopP          float64
-	Temperature   float64
-	TopK          int64
+	toolsProvider  *ToolsProvider
+	MaxToken       int64
+	TopP           float64
+	Temperature    float64
+	TopK           int64
+	DisableTracing bool
+}
+
+func WithTracingDisabled() RequestOption {
+	return func(c *LLMRequestConfig) {
+		c.DisableTracing = true
+	}
 }
 
 // NewRequestConfig creates a new config with default values.


### PR DESCRIPTION
This pull request introduces a new tracing mechanism for LLM providers and refactors tool handling to allow for filtering based on allowed tools. The most important changes include the addition of a `TracingLLMProvider`, modifications to the `LLMRequest` struct to support tracing, and changes to the tool listing and execution process.

### Tracing Mechanism:

* [`llm.go`](diffhunk://#diff-8f25989fee211f872264334354217c9b60c1360228f1890635844d0aacfcbf5aR34-R42): Updated the `NewLLMRequest` function to conditionally wrap the provider with a `TracingLLMProvider` if tracing is not disabled.
* [`tracing_llm_provider.go`](diffhunk://#diff-78b7f911423351856c0f424dbb973f9b55931398a9fe217407c959d4582fb627R1-R95): Added the `TracingLLMProvider` implementation, which decorates LLM providers with tracing capabilities.
* [`types.go`](diffhunk://#diff-b990161986c40e0867e71c60779bc98a8730a9eb0ca5866ae8189e126863c059R39-R46): Introduced `DisableTracing` and `WithTracingDisabled` to the `LLMRequestConfig` struct to control tracing behavior.

### Tool Handling:

* [`tools_provider.go`](diffhunk://#diff-a2ca8a83e16290f5e1075cd4ffc2436d47e6e80435f4ea78c5716243b63d7bbfL48-R76): Modified the `ListTools` method to accept a list of allowed tools and filter the returned tools accordingly.
* `llm_provider_anthropic.go` and `llm_provider_openai.go`: Updated the `ListTools` method calls to pass the allowed tools from the configuration. [[1]](diffhunk://#diff-f9087be89828f09a9531b695f2e8b8a6df1a67d2b2e83e4d2784ee223f4918e7L141-L145) [[2]](diffhunk://#diff-19bdea5cc92c5bad6ea9868bc31b918edd9fbd453ce549dc93448d2ceaaaf9baL109-R109)

### Refactoring:

* [`llm_provider_anthropic.go`](diffhunk://#diff-f9087be89828f09a9531b695f2e8b8a6df1a67d2b2e83e4d2784ee223f4918e7L102-L120): Removed observability spans and related attributes to streamline the code and rely on the new tracing mechanism. [[1]](diffhunk://#diff-f9087be89828f09a9531b695f2e8b8a6df1a67d2b2e83e4d2784ee223f4918e7L102-L120) [[2]](diffhunk://#diff-f9087be89828f09a9531b695f2e8b8a6df1a67d2b2e83e4d2784ee223f4918e7L156-L186) [[3]](diffhunk://#diff-f9087be89828f09a9531b695f2e8b8a6df1a67d2b2e83e4d2784ee223f4918e7L196-L219) [[4]](diffhunk://#diff-f9087be89828f09a9531b695f2e8b8a6df1a67d2b2e83e4d2784ee223f4918e7L234-L238) [[5]](diffhunk://#diff-f9087be89828f09a9531b695f2e8b8a6df1a67d2b2e83e4d2784ee223f4918e7L249-L255)