### PR TITLE
Add client cleanup and improve message handling in SSEServer

### DIFF
--- a/mcp/client_sse.go
+++ b/mcp/client_sse.go
@@ -168,7 +168,7 @@ func (t *SSETransport) connectionManager(ctx context.Context, config ClientConfi
 		case <-t.stopChan:
 			return
 		default:
-			if t.getState() != Connecting && t.getState() != Disconnected {
+			if t.getState() != Connecting {
 				select {
 				case <-t.stopChan:
 					return
@@ -394,12 +394,14 @@ func (t *SSETransport) processEventStream(ctx context.Context, reader io.Reader,
 	// Handle EOF
 	t.logger.Debug("Event stream closed unexpected due to possibly EOF")
 	errChan <- fmt.Errorf("event stream closed unexpectedly")
+	t.setState(Disconnected)
 	select {
 	case t.reconnectChan <- struct{}{}:
 	default:
 		t.logger.Debug("Reconnect channel is full. But it's OK")
 	}
 }
+
 func (t *SSETransport) processEvent(
 	event map[string]string,
 	messageEndpointChan chan string,

--- a/mcp/server_stdio_test.go
+++ b/mcp/server_stdio_test.go
@@ -28,7 +28,7 @@ func waitForResponse(t *testing.T, out *bytes.Buffer, timeout time.Duration) *Re
 			}
 			return &response
 		}
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 	}
 	t.Fatal("Timeout waiting for response")
 	return nil


### PR DESCRIPTION
This pull request includes several changes to the `SSEServer` implementation in the `mcp/server_sse.go` file to improve client management and error handling. Additionally, there is a minor adjustment in the test file `mcp/server_stdio_test.go`.

Improvements to client management and error handling:

* Added `activeConnections` field to `SSEServer` struct to track active connections.
* Modified `sendMessageToClient` method to handle non-existent clients and use a non-blocking send with a timeout, improving error logging and client cleanup.
* Enhanced `Run` method to include client cleanup when the context is canceled, ensuring all clients are properly removed.
* Added `removeClient` method to encapsulate client removal logic, ensuring proper cleanup of client channels and active connections.

Test adjustments:

* Increased sleep duration in `waitForResponse` test helper function to reduce flakiness in tests.Introduced client cleanup logic to handle unresponsive or disconnected clients. Improved message sending with a non-blocking timeout mechanism to prevent blocking on full buffers. Added `activeConnections` tracking and a `removeClient` helper for better resource management.