### PR TITLE
CI: Add Matrix Testing Strategy for Multiple Go Versions

### DIFF
--- a/.github/workflows/go-matrix-test.yml
+++ b/.github/workflows/go-matrix-test.yml
@@ -1,0 +1,30 @@
+name: Go Matrix Testing
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.22.x, 1.23.x, 1.24.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ matrix.go-version }}
+    
+    - name: Install dependencies
+      run: go mod download
+    
+    - name: Run tests
+      run: go test ./... -v


### PR DESCRIPTION
Implements matrix testing for Go versions 1.22, 1.23, and 1.24 across multiple operating systems.

Resolves #33

Changes:
- Added GitHub Actions workflow for matrix testing
- Covers Ubuntu, macOS, and Windows
- Tests against Go versions 1.22.x, 1.23.x, and 1.24.x