### PR TITLE
Moved public property for request config to private property

### DIFF
--- a/llm.go
+++ b/llm.go
@@ -31,7 +31,7 @@ type LLMRequest struct {
 //	// Create LLM request client
 //	llm := goai.NewLLMRequest(config, provider)
 func NewLLMRequest(config LLMRequestConfig, provider LLMProvider) *LLMRequest {
-	if !config.DisableTracing {
+	if !config.enableTracing {
 		if _, isAlreadyTraced := provider.(*TracingLLMProvider); !isAlreadyTraced {
 			provider = NewTracingLLMProvider(provider)
 		}

--- a/llm_provider_anthropic.go
+++ b/llm_provider_anthropic.go
@@ -77,9 +77,9 @@ func (p *AnthropicLLMProvider) prepareMessageParams(messages []LLMMessage, confi
 	params := anthropic.MessageNewParams{
 		Model:       anthropic.F(p.model),
 		Messages:    anthropic.F(anthropicMessages),
-		MaxTokens:   anthropic.F(config.MaxToken),
-		TopP:        anthropic.Float(config.TopP),
-		Temperature: anthropic.Float(config.Temperature),
+		MaxTokens:   anthropic.F(config.maxToken),
+		TopP:        anthropic.Float(config.topP),
+		Temperature: anthropic.Float(config.temperature),
 	}
 
 	// Add system message if present
@@ -115,7 +115,7 @@ func (p *AnthropicLLMProvider) GetResponse(ctx context.Context, messages []LLMMe
 	}
 
 	// Prepare tools if registry exists
-	mcpTools, err := config.toolsProvider.ListTools(ctx, config.AllowedTools)
+	mcpTools, err := config.toolsProvider.ListTools(ctx, config.allowedTools)
 	if err != nil {
 		return LLMResponse{}, fmt.Errorf("error listing tools: %w", err)
 	}
@@ -142,7 +142,7 @@ func (p *AnthropicLLMProvider) GetResponse(ctx context.Context, messages []LLMMe
 	for {
 		message, err := p.client.CreateMessage(ctx, anthropic.MessageNewParams{
 			Model:     anthropic.F(p.model),
-			MaxTokens: anthropic.F(config.MaxToken),
+			MaxTokens: anthropic.F(config.maxToken),
 			Messages:  anthropic.F(anthropicMessages),
 			Tools:     anthropic.F(toolUnionParams),
 		})

--- a/llm_provider_anthropic_streaming.go
+++ b/llm_provider_anthropic_streaming.go
@@ -54,7 +54,7 @@ func (p *AnthropicLLMProvider) convertToAnthropicMessages(messages []LLMMessage)
 
 // prepareTools prepares the tool definitions for the Anthropic API
 func (p *AnthropicLLMProvider) prepareTools(ctx context.Context, config LLMRequestConfig) ([]anthropic.ToolUnionUnionParam, error) {
-	mcpTools, err := config.toolsProvider.ListTools(ctx, config.AllowedTools)
+	mcpTools, err := config.toolsProvider.ListTools(ctx, config.allowedTools)
 	if err != nil {
 		return nil, fmt.Errorf("error listing tools: %w", err)
 	}
@@ -149,7 +149,7 @@ func (p *AnthropicLLMProvider) streamAndProcessMessage(
 ) (*anthropic.Message, error) {
 	msgParam := anthropic.MessageNewParams{
 		Model:     anthropic.F(p.model),
-		MaxTokens: anthropic.F(config.MaxToken),
+		MaxTokens: anthropic.F(config.maxToken),
 		Messages:  anthropic.F(anthropicMessages),
 		Tools:     anthropic.F(toolUnionParams),
 	}

--- a/llm_provider_anthropic_test.go
+++ b/llm_provider_anthropic_test.go
@@ -147,9 +147,9 @@ func TestAnthropicLLMProvider_GetResponse(t *testing.T) {
 				{Role: AssistantRole, Text: "Hi there"},
 			},
 			config: LLMRequestConfig{
-				MaxToken:      100,
-				TopP:          0.9,
-				Temperature:   0.7,
+				maxToken:      100,
+				topP:          0.9,
+				temperature:   0.7,
 				toolsProvider: NewToolsProvider(),
 			},
 			expectedResult: LLMResponse{
@@ -276,9 +276,9 @@ func TestAnthropicLLMProvider_GetResponse_WithTools(t *testing.T) {
 				{Role: UserRole, Text: "Use the test tool"},
 			},
 			config: LLMRequestConfig{
-				MaxToken:      100,
-				TopP:          0.9,
-				Temperature:   0.7,
+				maxToken:      100,
+				topP:          0.9,
+				temperature:   0.7,
 				toolsProvider: toolsProvider,
 			},
 			mockResponses: []*anthropic.Message{
@@ -328,9 +328,9 @@ func TestAnthropicLLMProvider_GetResponse_WithTools(t *testing.T) {
 				{Role: UserRole, Text: "Use a tool"},
 			},
 			config: LLMRequestConfig{
-				MaxToken:      100,
-				TopP:          0.9,
-				Temperature:   0.7,
+				maxToken:      100,
+				topP:          0.9,
+				temperature:   0.7,
 				toolsProvider: NewToolsProvider(),
 			},
 			mockResponses: []*anthropic.Message{
@@ -458,7 +458,7 @@ func TestAnthropicLLMProvider_GetStreamingResponse_Basic(t *testing.T) {
 	ctx := context.Background()
 	stream, err := provider.GetStreamingResponse(ctx, []LLMMessage{
 		{Role: UserRole, Text: "Hello"},
-	}, LLMRequestConfig{MaxToken: 100, toolsProvider: func() *ToolsProvider {
+	}, LLMRequestConfig{maxToken: 100, toolsProvider: func() *ToolsProvider {
 		return NewToolsProvider()
 	}()})
 	assert.NoError(t, err)
@@ -620,9 +620,9 @@ func TestAnthropicLLMProvider_GetStreamingResponse_SingleTool(t *testing.T) {
 	stream, err := provider.GetStreamingResponse(ctx, []LLMMessage{
 		{Role: UserRole, Text: "Weather in Berlin?"},
 	}, LLMRequestConfig{
-		MaxToken:      100,
+		maxToken:      100,
 		toolsProvider: mockToolsProvider,
-		AllowedTools:  []string{"get_weather"},
+		allowedTools:  []string{"get_weather"},
 	})
 	assert.NoError(t, err)
 
@@ -799,9 +799,9 @@ func TestAnthropicLLMProvider_GetStreamingResponse_MultiTool(t *testing.T) {
 	stream, err := provider.GetStreamingResponse(ctx, []LLMMessage{
 		{Role: UserRole, Text: "What's the weather in Berlin and GOOGL stock price?"},
 	}, LLMRequestConfig{
-		MaxToken:      200,
+		maxToken:      200,
 		toolsProvider: mockToolsProvider,
-		AllowedTools:  []string{"get_weather", "get_stock_price"},
+		allowedTools:  []string{"get_weather", "get_stock_price"},
 	})
 	assert.NoError(t, err)
 

--- a/llm_provider_aws_bedrock.go
+++ b/llm_provider_aws_bedrock.go
@@ -60,9 +60,9 @@ func (p *BedrockLLMProvider) GetResponse(ctx context.Context, messages []LLMMess
 		ModelId:  &p.model,
 		Messages: bedrockMessages,
 		InferenceConfig: &types.InferenceConfiguration{
-			Temperature: aws.Float32(float32(config.Temperature)),
-			TopP:        aws.Float32(float32(config.TopP)),
-			MaxTokens:   aws.Int32(int32(config.MaxToken)),
+			Temperature: aws.Float32(float32(config.temperature)),
+			TopP:        aws.Float32(float32(config.topP)),
+			MaxTokens:   aws.Int32(int32(config.maxToken)),
 		},
 	}
 
@@ -169,9 +169,9 @@ func (p *BedrockLLMProvider) GetStreamingResponse(ctx context.Context, messages 
 		ModelId:  &p.model,
 		Messages: bedrockMessages,
 		InferenceConfig: &types.InferenceConfiguration{
-			Temperature: aws.Float32(float32(config.Temperature)),
-			TopP:        aws.Float32(float32(config.TopP)),
-			MaxTokens:   aws.Int32(int32(config.MaxToken)),
+			Temperature: aws.Float32(float32(config.temperature)),
+			TopP:        aws.Float32(float32(config.topP)),
+			MaxTokens:   aws.Int32(int32(config.maxToken)),
 		},
 	}
 

--- a/llm_provider_gemini.go
+++ b/llm_provider_gemini.go
@@ -51,11 +51,11 @@ func (p *GeminiProvider) GetResponse(ctx context.Context, messages []LLMMessage,
 
 	var activeTools map[string]mcp.Tool
 	var genaiTools []*genai.Tool
-	if len(config.AllowedTools) > 0 {
+	if len(config.allowedTools) > 0 {
 		if config.toolsProvider == nil {
 			return LLMResponse{}, errors.New("request config allows tools but provides no toolsProvider")
 		}
-		fetchedTools, err := config.toolsProvider.ListTools(ctx, config.AllowedTools)
+		fetchedTools, err := config.toolsProvider.ListTools(ctx, config.allowedTools)
 		if err != nil {
 			return LLMResponse{}, fmt.Errorf("failed to get tools from config.toolsProvider: %w", err)
 		}
@@ -235,11 +235,11 @@ func (p *GeminiProvider) GetStreamingResponse(ctx context.Context, messages []LL
 	}
 	var activeTools map[string]mcp.Tool
 	var genaiTools []*genai.Tool
-	if len(config.AllowedTools) > 0 {
+	if len(config.allowedTools) > 0 {
 		if config.toolsProvider == nil {
 			return nil, errors.New("request config allows tools but provides no toolsProvider")
 		}
-		fetchedTools, err := config.toolsProvider.ListTools(ctx, config.AllowedTools)
+		fetchedTools, err := config.toolsProvider.ListTools(ctx, config.allowedTools)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get tools from config.toolsProvider: %w", err)
 		}
@@ -450,26 +450,26 @@ func (p *GeminiProvider) mapLLMMessagesToGenaiContent(messages []LLMMessage) ([]
 
 func mapLLMConfigToGenaiConfig(config LLMRequestConfig) (*genai.GenerationConfig, error) {
 	genaiConfig := &genai.GenerationConfig{}
-	if config.MaxToken > 0 {
-		if config.MaxToken > int64(^uint32(0)>>1) {
-			return nil, fmt.Errorf("MaxToken %d exceeds int32 limit", config.MaxToken)
+	if config.maxToken > 0 {
+		if config.maxToken > int64(^uint32(0)>>1) {
+			return nil, fmt.Errorf("maxToken %d exceeds int32 limit", config.maxToken)
 		}
-		maxTokens := int32(config.MaxToken)
+		maxTokens := int32(config.maxToken)
 		genaiConfig.MaxOutputTokens = &maxTokens
 	}
-	if config.Temperature >= 0 {
-		temp := float32(config.Temperature)
+	if config.temperature >= 0 {
+		temp := float32(config.temperature)
 		genaiConfig.Temperature = &temp
 	}
-	if config.TopP > 0 {
-		topP := float32(config.TopP)
+	if config.topP > 0 {
+		topP := float32(config.topP)
 		genaiConfig.TopP = &topP
 	}
-	if config.TopK > 0 {
-		if config.TopK > int64(^uint32(0)>>1) {
-			return nil, fmt.Errorf("TopK %d exceeds int32 limit", config.TopK)
+	if config.topK > 0 {
+		if config.topK > int64(^uint32(0)>>1) {
+			return nil, fmt.Errorf("topK %d exceeds int32 limit", config.topK)
 		}
-		topK := int32(config.TopK)
+		topK := int32(config.topK)
 		genaiConfig.TopK = &topK
 	}
 	return genaiConfig, nil

--- a/llm_provider_gemini_test.go
+++ b/llm_provider_gemini_test.go
@@ -172,7 +172,7 @@ func TestGeminiProvider_GetResponse_SingleToolCall(t *testing.T) {
 
 	messages := []LLMMessage{{Role: UserRole, Text: "Weather Berlin?"}}
 	config := LLMRequestConfig{
-		AllowedTools:  []string{"get_weather"},
+		allowedTools:  []string{"get_weather"},
 		toolsProvider: mockToolsProvider,
 	}
 
@@ -240,7 +240,7 @@ func TestGeminiProvider_GetResponse_MultipleToolCalls(t *testing.T) {
 
 	messages := []LLMMessage{{Role: UserRole, Text: "What is the capital of Germany and what's the weather like there?"}}
 	config := LLMRequestConfig{
-		AllowedTools:  []string{"get_capital", "get_weather"},
+		allowedTools:  []string{"get_capital", "get_weather"},
 		toolsProvider: mockToolsProvider,
 	}
 
@@ -377,7 +377,7 @@ func TestGeminiProvider_GetStreamingResponse_SingleToolCallSimulated(t *testing.
 
 	messages := []LLMMessage{{Role: UserRole, Text: "Weather London?"}}
 	config := LLMRequestConfig{
-		AllowedTools:  []string{"get_weather"},
+		allowedTools:  []string{"get_weather"},
 		toolsProvider: mockToolsProvider,
 	}
 
@@ -442,7 +442,7 @@ func TestGeminiProvider_GetStreamingResponse_MultipleToolCallsSimulated(t *testi
 
 	messages := []LLMMessage{{Role: UserRole, Text: "What is the capital of France and its weather?"}}
 	config := LLMRequestConfig{
-		AllowedTools:  []string{"get_capital", "get_weather"},
+		allowedTools:  []string{"get_capital", "get_weather"},
 		toolsProvider: mockToolsProvider,
 	}
 

--- a/llm_provider_openai.go
+++ b/llm_provider_openai.go
@@ -78,9 +78,9 @@ func (p *OpenAILLMProvider) createCompletionParams(messages []openai.ChatComplet
 	return openai.ChatCompletionNewParams{
 		Messages:    openai.F(messages),
 		Model:       openai.F(p.model),
-		MaxTokens:   openai.Int(config.MaxToken),
-		TopP:        openai.Float(config.TopP),
-		Temperature: openai.Float(config.Temperature),
+		MaxTokens:   openai.Int(config.maxToken),
+		TopP:        openai.Float(config.topP),
+		Temperature: openai.Float(config.temperature),
 	}
 }
 
@@ -106,7 +106,7 @@ func (p *OpenAILLMProvider) GetResponse(ctx context.Context, messages []LLMMessa
 
 	var tools []openai.ChatCompletionToolParam
 
-	toolLists, err := config.toolsProvider.ListTools(ctx, config.AllowedTools)
+	toolLists, err := config.toolsProvider.ListTools(ctx, config.allowedTools)
 	if err != nil {
 		return LLMResponse{}, fmt.Errorf("failed to list tools: %w", err)
 	}

--- a/llm_provider_openai_test.go
+++ b/llm_provider_openai_test.go
@@ -183,8 +183,8 @@ func TestOpenAILLMProvider_GetResponse_WithTools(t *testing.T) {
 				{Role: UserRole, Text: "What's the weather in New York?"},
 			},
 			config: LLMRequestConfig{
-				MaxToken:    100,
-				Temperature: 0.7,
+				maxToken:    100,
+				temperature: 0.7,
 				toolsProvider: func() *ToolsProvider {
 					provider := NewToolsProvider()
 					_ = provider.AddTools([]mcp.Tool{
@@ -257,8 +257,8 @@ func TestOpenAILLMProvider_GetResponse_WithTools(t *testing.T) {
 				{Role: UserRole, Text: "Hello"},
 			},
 			config: LLMRequestConfig{
-				MaxToken:      100,
-				Temperature:   0.7,
+				maxToken:      100,
+				temperature:   0.7,
 				toolsProvider: NewToolsProvider(),
 			},
 			responses: []string{

--- a/llm_test.go
+++ b/llm_test.go
@@ -48,9 +48,9 @@ func TestLLMRequest_Generate(t *testing.T) {
 		{
 			name: "successful generation",
 			config: LLMRequestConfig{
-				MaxToken:    100,
-				TopP:        0.9,
-				Temperature: 0.7,
+				maxToken:    100,
+				topP:        0.9,
+				temperature: 0.7,
 			},
 			mockResponse: LLMResponse{
 				Text:             "Hello, world!",
@@ -68,9 +68,9 @@ func TestLLMRequest_Generate(t *testing.T) {
 		{
 			name: "provider error",
 			config: LLMRequestConfig{
-				MaxToken:    100,
-				TopP:        0.9,
-				Temperature: 0.7,
+				maxToken:    100,
+				topP:        0.9,
+				temperature: 0.7,
 			},
 			mockError:     errors.New("provider error"),
 			expectedError: true,
@@ -127,7 +127,7 @@ func TestLLMRequest_GenerateStream(t *testing.T) {
 		{
 			name: "successful streaming",
 			config: LLMRequestConfig{
-				MaxToken: 100,
+				maxToken: 100,
 			},
 			messages: []LLMMessage{
 				{Role: UserRole, Text: "Hello"},
@@ -141,7 +141,7 @@ func TestLLMRequest_GenerateStream(t *testing.T) {
 		{
 			name: "provider error",
 			config: LLMRequestConfig{
-				MaxToken: 100,
+				maxToken: 100,
 			},
 			messages: []LLMMessage{
 				{Role: UserRole, Text: "Hello"},
@@ -152,7 +152,7 @@ func TestLLMRequest_GenerateStream(t *testing.T) {
 		{
 			name: "context cancellation",
 			config: LLMRequestConfig{
-				MaxToken: 100,
+				maxToken: 100,
 			},
 			messages: []LLMMessage{
 				{Role: UserRole, Text: "Hello"},

--- a/tracing_llm_provider.go
+++ b/tracing_llm_provider.go
@@ -40,10 +40,10 @@ func (t *TracingLLMProvider) GetResponse(ctx context.Context, messages []LLMMess
 		attribute.Int("total_output_token", response.TotalOutputToken),
 		attribute.Int("message_count", len(messages)),
 		attribute.Float64("completion_time", time.Since(startTime).Seconds()),
-		attribute.Int64("max_token", config.MaxToken),
-		attribute.Float64("temperature", config.Temperature),
-		attribute.Float64("top_p", config.TopP),
-		attribute.Int64("top_k", config.TopK),
+		attribute.Int64("max_token", config.maxToken),
+		attribute.Float64("temperature", config.temperature),
+		attribute.Float64("top_p", config.topP),
+		attribute.Int64("top_k", config.topK),
 	)
 
 	return response, nil

--- a/types.go
+++ b/types.go
@@ -20,31 +20,58 @@ const (
 
 	// SystemRole represents a message from the system
 	SystemRole LLMMessageRole = "system"
+
+	// DefaultMaxToken is the default maximum number of tokens for LLM responses
+	DefaultMaxToken int64 = 1000
+
+	// DefaultTopP is the default top-p sampling value for LLM responses
+	DefaultTopP float64 = 0.5
+
+	// DefaultTemperature is the default temperature value for LLM responses
+	DefaultTemperature float64 = 0.5
+
+	// DefaultTopK is the default top-k sampling value for LLM responses
+	DefaultTopK int64 = 40
+
+	// DefaultMaxIterations is the default maximum number of iterations for LLM responses
+	DefaultMaxIterations int = 10
 )
 
 // DefaultConfig holds the default values for LLMRequestConfig
 var DefaultConfig = LLMRequestConfig{
-	MaxToken:      500,
-	TopP:          0.5,
-	Temperature:   0.5,
-	TopK:          40,
+	maxToken:      DefaultMaxToken,
+	topP:          DefaultTopP,
+	temperature:   DefaultTemperature,
+	topK:          DefaultTopK,
 	toolsProvider: NewToolsProvider(),
+	enableTracing: false,
+	allowedTools:  []string{},
+	maxIterations: DefaultMaxIterations,
 }
 
 // LLMRequestConfig defines configuration parameters for LLM requests.
 type LLMRequestConfig struct {
-	toolsProvider  *ToolsProvider
-	MaxToken       int64
-	TopP           float64
-	Temperature    float64
-	TopK           int64
-	DisableTracing bool
-	AllowedTools   []string
+	toolsProvider *ToolsProvider
+	maxToken      int64
+	topP          float64
+	temperature   float64
+	topK          int64
+	enableTracing bool
+	allowedTools  []string
+	maxIterations int
 }
 
-func WithTracingDisabled() RequestOption {
+// WithTracingEnabled sets the tracing option for the LLM request configuration.
+func WithTracingEnabled() RequestOption {
 	return func(c *LLMRequestConfig) {
-		c.DisableTracing = true
+		c.enableTracing = true
+	}
+}
+
+// WithMaxIterations sets the maximum number of iterations for the LLM request.
+func WithMaxIterations(maxIterations int) RequestOption {
+	return func(c *LLMRequestConfig) {
+		c.maxIterations = maxIterations
 	}
 }
 
@@ -68,7 +95,7 @@ type RequestOption func(*LLMRequestConfig)
 func WithMaxToken(maxToken int64) RequestOption {
 	return func(c *LLMRequestConfig) {
 		if maxToken > 0 {
-			c.MaxToken = maxToken
+			c.maxToken = maxToken
 		}
 	}
 }
@@ -77,7 +104,7 @@ func WithMaxToken(maxToken int64) RequestOption {
 func WithTopP(topP float64) RequestOption {
 	return func(c *LLMRequestConfig) {
 		if topP > 0 {
-			c.TopP = topP
+			c.topP = topP
 		}
 	}
 }
@@ -86,7 +113,7 @@ func WithTopP(topP float64) RequestOption {
 func WithTemperature(temp float64) RequestOption {
 	return func(c *LLMRequestConfig) {
 		if temp > 0 {
-			c.Temperature = temp
+			c.temperature = temp
 		}
 	}
 }
@@ -95,7 +122,7 @@ func WithTemperature(temp float64) RequestOption {
 func WithTopK(topK int64) RequestOption {
 	return func(c *LLMRequestConfig) {
 		if topK > 0 {
-			c.TopK = topK
+			c.topK = topK
 		}
 	}
 }
@@ -108,7 +135,7 @@ func UseToolsProvider(provider *ToolsProvider) RequestOption {
 
 func WithAllowedTools(allowedTools []string) RequestOption {
 	return func(c *LLMRequestConfig) {
-		c.AllowedTools = allowedTools
+		c.allowedTools = allowedTools
 	}
 }
 

--- a/types_test.go
+++ b/types_test.go
@@ -13,10 +13,12 @@ func TestNewRequestConfig(t *testing.T) {
 		{
 			name: "no options - should use defaults",
 			expected: LLMRequestConfig{
-				MaxToken:    500,
-				TopP:        0.5,
-				Temperature: 0.5,
-				TopK:        40,
+				maxToken:      1000,
+				topP:          0.5,
+				temperature:   0.5,
+				topK:          40,
+				enableTracing: false,
+				toolsProvider: NewToolsProvider(),
 			},
 		},
 		{
@@ -25,10 +27,10 @@ func TestNewRequestConfig(t *testing.T) {
 				WithMaxToken(2000),
 			},
 			expected: LLMRequestConfig{
-				MaxToken:    2000,
-				TopP:        0.5,
-				Temperature: 0.5,
-				TopK:        40,
+				maxToken:    2000,
+				topP:        0.5,
+				temperature: 0.5,
+				topK:        40,
 			},
 		},
 		{
@@ -40,10 +42,10 @@ func TestNewRequestConfig(t *testing.T) {
 				WithTopK(100),
 			},
 			expected: LLMRequestConfig{
-				MaxToken:    2000,
-				TopP:        0.95,
-				Temperature: 0.8,
-				TopK:        100,
+				maxToken:    2000,
+				topP:        0.95,
+				temperature: 0.8,
+				topK:        100,
 			},
 		},
 		{
@@ -55,10 +57,10 @@ func TestNewRequestConfig(t *testing.T) {
 				WithTopK(0),
 			},
 			expected: LLMRequestConfig{
-				MaxToken:    500,
-				TopP:        0.5,
-				Temperature: 0.5,
-				TopK:        40,
+				maxToken:    1000,
+				topP:        0.5,
+				temperature: 0.5,
+				topK:        40,
 			},
 		},
 		{
@@ -70,10 +72,10 @@ func TestNewRequestConfig(t *testing.T) {
 				WithTopK(-10),
 			},
 			expected: LLMRequestConfig{
-				MaxToken:    500,
-				TopP:        0.5,
-				Temperature: 0.5,
-				TopK:        40,
+				maxToken:    1000,
+				topP:        0.5,
+				temperature: 0.5,
+				topK:        40,
 			},
 		},
 		{
@@ -85,10 +87,10 @@ func TestNewRequestConfig(t *testing.T) {
 				WithTopK(0),
 			},
 			expected: LLMRequestConfig{
-				MaxToken:    2000,
-				TopP:        0.5,
-				Temperature: 0.8,
-				TopK:        40,
+				maxToken:    2000,
+				topP:        0.5,
+				temperature: 0.8,
+				topK:        40,
 			},
 		},
 	}
@@ -97,17 +99,17 @@ func TestNewRequestConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := NewRequestConfig(tt.opts...)
 
-			if result.MaxToken != tt.expected.MaxToken {
-				t.Errorf("MaxToken: expected %d, got %d", tt.expected.MaxToken, result.MaxToken)
+			if result.maxToken != tt.expected.maxToken {
+				t.Errorf("maxToken: expected %d, got %d", tt.expected.maxToken, result.maxToken)
 			}
-			if result.TopP != tt.expected.TopP {
-				t.Errorf("TopP: expected %f, got %f", tt.expected.TopP, result.TopP)
+			if result.topP != tt.expected.topP {
+				t.Errorf("topP: expected %f, got %f", tt.expected.topP, result.topP)
 			}
-			if result.Temperature != tt.expected.Temperature {
-				t.Errorf("Temperature: expected %f, got %f", tt.expected.Temperature, result.Temperature)
+			if result.temperature != tt.expected.temperature {
+				t.Errorf("temperature: expected %f, got %f", tt.expected.temperature, result.temperature)
 			}
-			if result.TopK != tt.expected.TopK {
-				t.Errorf("TopK: expected %d, got %d", tt.expected.TopK, result.TopK)
+			if result.topK != tt.expected.topK {
+				t.Errorf("topK: expected %d, got %d", tt.expected.topK, result.topK)
 			}
 		})
 	}
@@ -131,12 +133,12 @@ func TestWithMaxToken(t *testing.T) {
 			WithMaxToken(tt.input)(&config)
 
 			if tt.shouldApply {
-				if config.MaxToken != tt.input {
-					t.Errorf("expected MaxToken to be %d, got %d", tt.input, config.MaxToken)
+				if config.maxToken != tt.input {
+					t.Errorf("expected maxToken to be %d, got %d", tt.input, config.maxToken)
 				}
 			} else {
-				if config.MaxToken != DefaultConfig.MaxToken {
-					t.Errorf("expected MaxToken to remain %d, got %d", DefaultConfig.MaxToken, config.MaxToken)
+				if config.maxToken != DefaultConfig.maxToken {
+					t.Errorf("expected maxToken to remain %d, got %d", DefaultConfig.maxToken, config.maxToken)
 				}
 			}
 		})
@@ -160,12 +162,12 @@ func TestWithTopP(t *testing.T) {
 			WithTopP(tt.input)(&config)
 
 			if tt.shouldApply {
-				if config.TopP != tt.input {
-					t.Errorf("expected TopP to be %f, got %f", tt.input, config.TopP)
+				if config.topP != tt.input {
+					t.Errorf("expected topP to be %f, got %f", tt.input, config.topP)
 				}
 			} else {
-				if config.TopP != DefaultConfig.TopP {
-					t.Errorf("expected TopP to remain %f, got %f", DefaultConfig.TopP, config.TopP)
+				if config.topP != DefaultConfig.topP {
+					t.Errorf("expected topP to remain %f, got %f", DefaultConfig.topP, config.topP)
 				}
 			}
 		})
@@ -189,12 +191,12 @@ func TestWithTemperature(t *testing.T) {
 			WithTemperature(tt.input)(&config)
 
 			if tt.shouldApply {
-				if config.Temperature != tt.input {
-					t.Errorf("expected Temperature to be %f, got %f", tt.input, config.Temperature)
+				if config.temperature != tt.input {
+					t.Errorf("expected temperature to be %f, got %f", tt.input, config.temperature)
 				}
 			} else {
-				if config.Temperature != DefaultConfig.Temperature {
-					t.Errorf("expected Temperature to remain %f, got %f", DefaultConfig.Temperature, config.Temperature)
+				if config.temperature != DefaultConfig.temperature {
+					t.Errorf("expected temperature to remain %f, got %f", DefaultConfig.temperature, config.temperature)
 				}
 			}
 		})
@@ -218,12 +220,12 @@ func TestWithTopK(t *testing.T) {
 			WithTopK(tt.input)(&config)
 
 			if tt.shouldApply {
-				if config.TopK != tt.input {
-					t.Errorf("expected TopK to be %d, got %d", tt.input, config.TopK)
+				if config.topK != tt.input {
+					t.Errorf("expected topK to be %d, got %d", tt.input, config.topK)
 				}
 			} else {
-				if config.TopK != DefaultConfig.TopK {
-					t.Errorf("expected TopK to remain %d, got %d", DefaultConfig.TopK, config.TopK)
+				if config.topK != DefaultConfig.topK {
+					t.Errorf("expected topK to remain %d, got %d", DefaultConfig.topK, config.topK)
 				}
 			}
 		})


### PR DESCRIPTION
This pull request includes changes to standardize the naming convention for configuration parameters across various LLM providers. The most important changes include renaming configuration fields to use camelCase consistently and updating associated test cases.

### Configuration Parameter Standardization:

* [`llm.go`](diffhunk://#diff-8f25989fee211f872264334354217c9b60c1360228f1890635844d0aacfcbf5aL34-R34): Renamed `DisableTracing` to `enableTracing` in the `LLMRequestConfig` struct.
* [`llm_provider_anthropic.go`](diffhunk://#diff-f9087be89828f09a9531b695f2e8b8a6df1a67d2b2e83e4d2784ee223f4918e7L80-R82): Updated `MaxToken`, `TopP`, and `Temperature` to `maxToken`, `topP`, and `temperature` respectively in the `LLMRequestConfig` struct. [[1]](diffhunk://#diff-f9087be89828f09a9531b695f2e8b8a6df1a67d2b2e83e4d2784ee223f4918e7L80-R82) [[2]](diffhunk://#diff-f9087be89828f09a9531b695f2e8b8a6df1a67d2b2e83e4d2784ee223f4918e7L118-R118) [[3]](diffhunk://#diff-f9087be89828f09a9531b695f2e8b8a6df1a67d2b2e83e4d2784ee223f4918e7L145-R145)
* [`llm_provider_aws_bedrock.go`](diffhunk://#diff-ad227711e810af457326168ea36579813d90e25b85aacd44f70cc1029f4b9a4fL63-R65): Changed `MaxToken`, `TopP`, and `Temperature` to `maxToken`, `topP`, and `temperature` respectively in the `LLMRequestConfig` struct. [[1]](diffhunk://#diff-ad227711e810af457326168ea36579813d90e25b85aacd44f70cc1029f4b9a4fL63-R65) [[2]](diffhunk://#diff-ad227711e810af457326168ea36579813d90e25b85aacd44f70cc1029f4b9a4fL172-R174)
* [`llm_provider_gemini.go`](diffhunk://#diff-b8b477c6d04ed36d8d1dabed4380e0ac595e9d74f02f649b397450d6a9e0e098L54-R58): Modified `AllowedTools` to `allowedTools` and other related configuration parameters to camelCase. [[1]](diffhunk://#diff-b8b477c6d04ed36d8d1dabed4380e0ac595e9d74f02f649b397450d6a9e0e098L54-R58) [[2]](diffhunk://#diff-b8b477c6d04ed36d8d1dabed4380e0ac595e9d74f02f649b397450d6a9e0e098L238-R242) [[3]](diffhunk://#diff-b8b477c6d04ed36d8d1dabed4380e0ac595e9d74f02f649b397450d6a9e0e098L453-R472)
* [`llm_provider_openai.go`](diffhunk://#diff-19bdea5cc92c5bad6ea9868bc31b918edd9fbd453ce549dc93448d2ceaaaf9baL81-R83): Adjusted `MaxToken`, `TopP`, and `Temperature` to `maxToken`, `topP`, and `temperature` respectively in the `LLMRequestConfig` struct. [[1]](diffhunk://#diff-19bdea5cc92c5bad6ea9868bc31b918edd9fbd453ce549dc93448d2ceaaaf9baL81-R83) [[2]](diffhunk://#diff-19bdea5cc92c5bad6ea9868bc31b918edd9fbd453ce549dc93448d2ceaaaf9baL109-R109)

### Test Case Updates:

* [`llm_provider_anthropic_test.go`](diffhunk://#diff-23654cbc19555a13ad1b26f00d123e0e0ccba02ebb8bacda151db0cfab2b0b30L150-R152): Updated test cases to reflect the new camelCase naming for configuration parameters. [[1]](diffhunk://#diff-23654cbc19555a13ad1b26f00d123e0e0ccba02ebb8bacda151db0cfab2b0b30L150-R152) [[2]](diffhunk://#diff-23654cbc19555a13ad1b26f00d123e0e0ccba02ebb8bacda151db0cfab2b0b30L279-R281) [[3]](diffhunk://#diff-23654cbc19555a13ad1b26f00d123e0e0ccba02ebb8bacda151db0cfab2b0b30L331-R333) [[4]](diffhunk://#diff-23654cbc19555a13ad1b26f00d123e0e0ccba02ebb8bacda151db0cfab2b0b30L461-R461) [[5]](diffhunk://#diff-23654cbc19555a13ad1b26f00d123e0e0ccba02ebb8bacda151db0cfab2b0b30L623-R625) [[6]](diffhunk://#diff-23654cbc19555a13ad1b26f00d123e0e0ccba02ebb8bacda151db0cfab2b0b30L802-R804)
* [`llm_provider_gemini_test.go`](diffhunk://#diff-9321dec260866bc8b01932c3d45267ede4d18d52cebba01234c7857e15283786L175-R175): Modified test cases to use the new camelCase configuration parameters. [[1]](diffhunk://#diff-9321dec260866bc8b01932c3d45267ede4d18d52cebba01234c7857e15283786L175-R175) [[2]](diffhunk://#diff-9321dec260866bc8b01932c3d45267ede4d18d52cebba01234c7857e15283786L243-R243) [[3]](diffhunk://#diff-9321dec260866bc8b01932c3d45267ede4d18d52cebba01234c7857e15283786L380-R380) [[4]](diffhunk://#diff-9321dec260866bc8b01932c3d45267ede4d18d52cebba01234c7857e15283786L445-R445)
* [`llm_provider_openai_test.go`](diffhunk://#diff-fa288fbe608371688db5610e363653f354fd44bb2e954f672b7b6d027e76c3faL186-R187): Updated test cases to match the camelCase naming convention for configuration parameters. [[1]](diffhunk://#diff-fa288fbe608371688db5610e363653f354fd44bb2e954f672b7b6d027e76c3faL186-R187) [[2]](diffhunk://#diff-fa288fbe608371688db5610e363653f354fd44bb2e954f672b7b6d027e76c3faL260-R261)
* [`llm_test.go`](diffhunk://#diff-f0e34b2d8fa2f2f1b4ffc3c288efd61dd202352326caf22eca20773f842383a7L51-R53): Adjusted test cases to use camelCase for configuration parameters. [[1]](diffhunk://#diff-f0e34b2d8fa2f2f1b4ffc3c288efd61dd202352326caf22eca20773f842383a7L51-R53) [[2]](diffhunk://#diff-f0e34b2d8fa2f2f1b4ffc3c288efd61dd202352326caf22eca20773f842383a7L71-R73) [[3]](diffhunk://#diff-f0e34b2d8fa2f2f1b4ffc3c288efd61dd202352326caf22eca20773f842383a7L130-R130) [[4]](diffhunk://#diff-f0e34b2d8fa2f2f1b4ffc3c288efd61dd202352326caf22eca20773f842383a7L144-R144) [[5]](diffhunk://#diff-f0e34b2d8fa2f2f1b4ffc3c288efd61dd202352326caf22eca20773f842383a7L155-R155)
* [`tracing_llm_provider.go`](diffhunk://#diff-78b7f911423351856c0f424dbb973f9b55931398a9fe217407c959d4582fb627L43-R46): Renamed configuration parameters to camelCase in the tracing attributes.