### PR TITLE
Add thinking feature and chat history storage can store input and output token in the history

### DIFF
--- a/chat_history_types.go
+++ b/chat_history_types.go
@@ -7,6 +7,8 @@ import (
 type ChatHistoryMessage struct {
 	LLMMessage
 	GeneratedAt time.Time `json:"generated_at"`
+	InputToken  int64     `json:"input_token"`
+	OutputToken int64     `json:"output_token"`
 }
 
 // ChatHistory defines the interface for conversation history storage

--- a/llm_provider_anthropic.go
+++ b/llm_provider_anthropic.go
@@ -145,7 +145,7 @@ func (p *AnthropicLLMProvider) GetResponse(ctx context.Context, messages []LLMMe
 		Tools:     anthropic.F(toolUnionParams),
 	}
 
-	if config.enableThinking {
+	if config.enableThinking && config.thinkingBudgetToken > 0 {
 		msgParams.Thinking = anthropic.F(anthropic.ThinkingConfigParamUnion(anthropic.ThinkingConfigParam{
 			Type:         anthropic.F(anthropic.ThinkingConfigParamTypeEnabled),
 			BudgetTokens: anthropic.Int(config.thinkingBudgetToken),

--- a/llm_provider_anthropic_streaming.go
+++ b/llm_provider_anthropic_streaming.go
@@ -154,6 +154,13 @@ func (p *AnthropicLLMProvider) streamAndProcessMessage(
 		Tools:     anthropic.F(toolUnionParams),
 	}
 
+	if config.enableThinking && config.thinkingBudgetToken > 0 {
+		msgParam.Thinking = anthropic.F(anthropic.ThinkingConfigParamUnion(anthropic.ThinkingConfigParam{
+			Type:         anthropic.F(anthropic.ThinkingConfigParamTypeEnabled),
+			BudgetTokens: anthropic.Int(config.thinkingBudgetToken),
+		}))
+	}
+
 	if systemMessage != "" {
 		msgParam.System = anthropic.F([]anthropic.TextBlockParam{
 			anthropic.NewTextBlock(systemMessage),

--- a/types.go
+++ b/types.go
@@ -49,14 +49,30 @@ var DefaultConfig = LLMRequestConfig{
 
 // LLMRequestConfig defines configuration parameters for LLM requests.
 type LLMRequestConfig struct {
-	toolsProvider *ToolsProvider
-	maxToken      int64
-	topP          float64
-	temperature   float64
-	topK          int64
-	enableTracing bool
-	allowedTools  []string
-	maxIterations int
+	toolsProvider       *ToolsProvider
+	maxToken            int64
+	topP                float64
+	temperature         float64
+	topK                int64
+	enableTracing       bool
+	allowedTools        []string
+	maxIterations       int
+	enableThinking      bool
+	thinkingBudgetToken int64
+}
+
+// WithThinkingBudget sets the thinking budget for the LLM request configuration.
+func WithThinkingBudget(budget int64) RequestOption {
+	return func(c *LLMRequestConfig) {
+		c.thinkingBudgetToken = budget
+	}
+}
+
+// WithThinkingEnabled sets the thinking option for the LLM request configuration.
+func WithThinkingEnabled() RequestOption {
+	return func(c *LLMRequestConfig) {
+		c.enableThinking = true
+	}
 }
 
 // WithTracingEnabled sets the tracing option for the LLM request configuration.

--- a/types.go
+++ b/types.go
@@ -61,17 +61,11 @@ type LLMRequestConfig struct {
 	thinkingBudgetToken int64
 }
 
-// WithThinkingBudget sets the thinking budget for the LLM request configuration.
-func WithThinkingBudget(budget int64) RequestOption {
-	return func(c *LLMRequestConfig) {
-		c.thinkingBudgetToken = budget
-	}
-}
-
 // WithThinkingEnabled sets the thinking option for the LLM request configuration.
-func WithThinkingEnabled() RequestOption {
+func WithThinkingEnabled(thinkingBudget int64) RequestOption {
 	return func(c *LLMRequestConfig) {
 		c.enableThinking = true
+		c.thinkingBudgetToken = thinkingBudget
 	}
 }
 
@@ -108,36 +102,28 @@ type RequestOption func(*LLMRequestConfig)
 // WithMaxToken sets the max token value
 func WithMaxToken(maxToken int64) RequestOption {
 	return func(c *LLMRequestConfig) {
-		if maxToken > 0 {
-			c.maxToken = maxToken
-		}
+		c.maxToken = maxToken
 	}
 }
 
 // WithTopP sets the top-p value
 func WithTopP(topP float64) RequestOption {
 	return func(c *LLMRequestConfig) {
-		if topP > 0 {
-			c.topP = topP
-		}
+		c.topP = topP
 	}
 }
 
 // WithTemperature sets the temperature value
 func WithTemperature(temp float64) RequestOption {
 	return func(c *LLMRequestConfig) {
-		if temp > 0 {
-			c.temperature = temp
-		}
+		c.temperature = temp
 	}
 }
 
 // WithTopK sets the top-k value
 func WithTopK(topK int64) RequestOption {
 	return func(c *LLMRequestConfig) {
-		if topK > 0 {
-			c.topK = topK
-		}
+		c.topK = topK
 	}
 }
 

--- a/types_test.go
+++ b/types_test.go
@@ -49,7 +49,7 @@ func TestNewRequestConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "with zero values - should not override defaults",
+			name: "with zero values - should override defaults",
 			opts: []RequestOption{
 				WithMaxToken(0),
 				WithTopP(0),
@@ -57,10 +57,10 @@ func TestNewRequestConfig(t *testing.T) {
 				WithTopK(0),
 			},
 			expected: LLMRequestConfig{
-				maxToken:    1000,
-				topP:        0.5,
-				temperature: 0.5,
-				topK:        40,
+				maxToken:    0,
+				topP:        0,
+				temperature: 0,
+				topK:        0,
 			},
 		},
 		{
@@ -72,10 +72,10 @@ func TestNewRequestConfig(t *testing.T) {
 				WithTopK(-10),
 			},
 			expected: LLMRequestConfig{
-				maxToken:    1000,
-				topP:        0.5,
-				temperature: 0.5,
-				topK:        40,
+				maxToken:    -100,
+				topP:        -0.5,
+				temperature: -0.3,
+				topK:        -10,
 			},
 		},
 		{
@@ -88,9 +88,9 @@ func TestNewRequestConfig(t *testing.T) {
 			},
 			expected: LLMRequestConfig{
 				maxToken:    2000,
-				topP:        0.5,
+				topP:        -0.5,
 				temperature: 0.8,
-				topK:        40,
+				topK:        0,
 			},
 		},
 	}
@@ -123,8 +123,8 @@ func TestWithMaxToken(t *testing.T) {
 		shouldApply bool
 	}{
 		{"positive value", 2000, true},
-		{"zero value", 0, false},
-		{"negative value", -100, false},
+		{"zero value", 0, true},
+		{"negative value", -100, true},
 	}
 
 	for _, tt := range tests {
@@ -152,8 +152,8 @@ func TestWithTopP(t *testing.T) {
 		shouldApply bool
 	}{
 		{"valid value", 0.95, true},
-		{"zero value", 0.0, false},
-		{"negative value", -0.5, false},
+		{"zero value", 0.0, true},
+		{"negative value", -0.5, true},
 	}
 
 	for _, tt := range tests {
@@ -181,8 +181,8 @@ func TestWithTemperature(t *testing.T) {
 		shouldApply bool
 	}{
 		{"valid value", 0.8, true},
-		{"zero value", 0.0, false},
-		{"negative value", -0.3, false},
+		{"zero value", 0.0, true},
+		{"negative value", -0.3, true},
 	}
 
 	for _, tt := range tests {
@@ -210,8 +210,8 @@ func TestWithTopK(t *testing.T) {
 		shouldApply bool
 	}{
 		{"valid value", 100, true},
-		{"zero value", 0, false},
-		{"negative value", -10, false},
+		{"zero value", 0, true},
+		{"negative value", -10, true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This pull request introduces several updates to enhance token tracking in SQLite chat history storage, implement a "thinking mode" for LLM providers, and adjust the handling of configuration defaults. Below is a breakdown of the most significant changes:

### SQLite Chat History Enhancements
* Added `input_token` and `output_token` columns to the `messages` table schema in `chat_history_sqlite.go` to track token usage for each message. (`[chat_history_sqlite.goL65-L70](diffhunk://#diff-5331ca2c9d89d103581bc563cbb525de9b6a99ee2d211ac8821b38baa5618a60L65-L70)`)
* Updated SQL queries and methods (`AddMessage`, `GetChat`, `ListChatHistories`) to handle the new token-related fields. (`[[1]](diffhunk://#diff-5331ca2c9d89d103581bc563cbb525de9b6a99ee2d211ac8821b38baa5618a60L149-R157)`, `[[2]](diffhunk://#diff-5331ca2c9d89d103581bc563cbb525de9b6a99ee2d211ac8821b38baa5618a60L192-R195)`, `[[3]](diffhunk://#diff-5331ca2c9d89d103581bc563cbb525de9b6a99ee2d211ac8821b38baa5618a60L202-R205)`, `[[4]](diffhunk://#diff-5331ca2c9d89d103581bc563cbb525de9b6a99ee2d211ac8821b38baa5618a60L261-R264)`, `[[5]](diffhunk://#diff-5331ca2c9d89d103581bc563cbb525de9b6a99ee2d211ac8821b38baa5618a60L272-R275)`)
* Extended the `ChatHistoryMessage` struct in `chat_history_types.go` to include `InputToken` and `OutputToken` fields. (`[chat_history_types.goR10-R11](diffhunk://#diff-915c7b631e7c8be6ff4322ad38958d36290d8270b9a19381284a67731dfa97baR10-R11)`)

### LLM Provider "Thinking Mode"
* Introduced a "thinking mode" configuration (`enableThinking` and `thinkingBudgetToken`) for LLM requests in `types.go`. (`[types.goR60-R69](diffhunk://#diff-b990161986c40e0867e71c60779bc98a8730a9eb0ca5866ae8189e126863c059R60-R69)`)
* Added support for "thinking mode" in the `AnthropicLLMProvider`, `BedrockLLMProvider`, and their streaming counterparts, allowing budgeted token allocation for intermediate reasoning steps. (`[[1]](diffhunk://#diff-f9087be89828f09a9531b695f2e8b8a6df1a67d2b2e83e4d2784ee223f4918e7L141-R157)`, `[[2]](diffhunk://#diff-d3e9aa4c3f4ab7b5f61134d1d2c4b282d9b0bf00a6ce6137ab2db8b3ea474517R157-R163)`, `[[3]](diffhunk://#diff-ad227711e810af457326168ea36579813d90e25b85aacd44f70cc1029f4b9a4fR120-R153)`, `[[4]](diffhunk://#diff-bee168cc0265ebf9e90c119200f03b3049cc88475abbd4ba7eb4dcc3b7c20696L158-R191)`)

### Configuration Defaults and Testing
* Removed restrictions on zero and negative values for configuration parameters (`maxToken`, `topP`, `temperature`, `topK`) in `types.go`. (`[types.goL95-L126](diffhunk://#diff-b990161986c40e0867e71c60779bc98a8730a9eb0ca5866ae8189e126863c059L95-L126)`)
* Updated test cases in `types_test.go` to reflect the new behavior, allowing zero and negative values to override defaults. (`[[1]](diffhunk://#diff-02776af2e303aa4b13cf883561bfd1aa91a940389c39aae1b7abbaecc0d68092L52-R63)`, `[[2]](diffhunk://#diff-02776af2e303aa4b13cf883561bfd1aa91a940389c39aae1b7abbaecc0d68092L75-R78)`, `[[3]](diffhunk://#diff-02776af2e303aa4b13cf883561bfd1aa91a940389c39aae1b7abbaecc0d68092L91-R93)`, `[[4]](diffhunk://#diff-02776af2e303aa4b13cf883561bfd1aa91a940389c39aae1b7abbaecc0d68092L126-R127)`, `[[5]](diffhunk://#diff-02776af2e303aa4b13cf883561bfd1aa91a940389c39aae1b7abbaecc0d68092L155-R156)`, `[[6]](diffhunk://#diff-02776af2e303aa4b13cf883561bfd1aa91a940389c39aae1b7abbaecc0d68092L184-R185)`, `[[7]](diffhunk://#diff-02776af2e303aa4b13cf883561bfd1aa91a940389c39aae1b7abbaecc0d68092L213-R214)`)