### PR TITLE
Add example client and server for SSE with `goai` library

### DIFF
--- a/_examples/simple_mcp_client.go
+++ b/_examples/simple_mcp_client.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/shaharia-lab/goai"
+	"log"
+	"time"
+)
+
+func main() {
+	sseConfig := goai.ClientConfig{
+		ClientName:    "MySSEClient",
+		ClientVersion: "1.0.0",
+		Logger:        goai.NewDefaultLogger(),
+		RetryDelay:    5 * time.Second,
+		MaxRetries:    3,
+		SSE: goai.SSEConfig{
+			URL: "http://localhost:8080/events", // Replace with your SSE endpoint
+		},
+	}
+	ctx := context.Background()
+	sseTransport := goai.NewSSETransport(goai.NewDefaultLogger())
+	sseClient := goai.NewClient(sseTransport, sseConfig)
+
+	if err := sseClient.Connect(ctx); err != nil {
+		log.Fatalf("SSE Client failed to connect: %v", err)
+	}
+	defer sseClient.Close(ctx)
+
+	tools, err := sseClient.ListTools(ctx)
+	if err != nil {
+		log.Fatalf("Failed to list tools (SSE): %v", err)
+	}
+	fmt.Printf("SSE Tools: %+v\n", tools)
+}

--- a/_examples/simple_mcp_server.go
+++ b/_examples/simple_mcp_server.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/shaharia-lab/goai"
+)
+
+func main() {
+	logger := goai.NewDefaultLogger()
+
+	tool := goai.Tool{
+		Name:        "get_weather",
+		Description: "Get weather for location",
+		InputSchema: json.RawMessage(`{
+        "type": "object",
+        "properties": {
+            "location": {"type": "string"}
+        },
+        "required": ["location"]
+    }`),
+		Handler: func(ctx context.Context, params goai.CallToolParams) (goai.CallToolResult, error) {
+			var input struct {
+				Location string `json:"location"`
+			}
+			json.Unmarshal(params.Arguments, &input)
+			return goai.CallToolResult{
+				Content: []goai.ToolResultContent{{
+					Type: "text",
+					Text: fmt.Sprintf("Weather in %s: Sunny", input.Location),
+				}},
+			}, nil
+		},
+	}
+
+	baseServer, err := goai.NewBaseServer(
+		goai.UseLogger(logger),
+	)
+	if err != nil {
+		panic(err)
+	}
+	baseServer.AddTools(tool)
+
+	server := goai.NewSSEServer(baseServer)
+	server.SetAddress(":8080")
+	ctx := context.Background()
+	server.Run(ctx)
+}


### PR DESCRIPTION
Introduced a simple SSE client and server implementation using the `goai` library. The client connects to an SSE endpoint and lists available tools, while the server provides a basic tool handling mechanism.