### PR TITLE
Update max iterations handling and default configuration

### DIFF
--- a/llm_provider_anthropic_streaming.go
+++ b/llm_provider_anthropic_streaming.go
@@ -22,7 +22,7 @@ func (p *AnthropicLLMProvider) GetStreamingResponse(ctx context.Context, message
 
 	responseChan := make(chan StreamingLLMResponse)
 
-	go p.processStreamingResponse(ctx, anthropicMessages, toolUnionParams, config, responseChan, systemMessage)
+	go p.processStreamingResponse(ctx, anthropicMessages, toolUnionParams, config, responseChan, systemMessage, config.maxIterations)
 
 	return responseChan, nil
 }
@@ -84,11 +84,11 @@ func (p *AnthropicLLMProvider) processStreamingResponse(
 	config LLMRequestConfig,
 	responseChan chan<- StreamingLLMResponse,
 	systemMessage string,
+	maxIterations int,
 ) {
 	defer close(responseChan)
 
 	iterations := 0
-	maxIterations := 10
 	keepProcessing := true
 
 	for keepProcessing && iterations < maxIterations {

--- a/llm_provider_anthropic_test.go
+++ b/llm_provider_anthropic_test.go
@@ -149,6 +149,7 @@ func TestAnthropicLLMProvider_GetResponse(t *testing.T) {
 				topP:          0.9,
 				temperature:   0.7,
 				toolsProvider: NewToolsProvider(),
+				maxIterations: 10,
 			},
 			expectedResult: LLMResponse{
 				Text:             "Test response",
@@ -331,6 +332,7 @@ func TestAnthropicLLMProvider_GetResponse_WithTools(t *testing.T) {
 				topP:          0.9,
 				temperature:   0.7,
 				toolsProvider: NewToolsProvider(),
+				maxIterations: 10,
 			},
 			mockResponses: []*anthropic.Message{
 				{
@@ -461,7 +463,7 @@ func TestAnthropicLLMProvider_GetStreamingResponse_Basic(t *testing.T) {
 	ctx := context.Background()
 	stream, err := provider.GetStreamingResponse(ctx, []LLMMessage{
 		{Role: UserRole, Text: "Hello"},
-	}, LLMRequestConfig{maxToken: 100, toolsProvider: func() *ToolsProvider {
+	}, LLMRequestConfig{maxIterations: 10, maxToken: 100, toolsProvider: func() *ToolsProvider {
 		return NewToolsProvider()
 	}()})
 	assert.NoError(t, err)
@@ -626,6 +628,7 @@ func TestAnthropicLLMProvider_GetStreamingResponse_SingleTool(t *testing.T) {
 		maxToken:      100,
 		toolsProvider: mockToolsProvider,
 		allowedTools:  []string{"get_weather"},
+		maxIterations: 10,
 	})
 	assert.NoError(t, err)
 
@@ -805,6 +808,7 @@ func TestAnthropicLLMProvider_GetStreamingResponse_MultiTool(t *testing.T) {
 		maxToken:      200,
 		toolsProvider: mockToolsProvider,
 		allowedTools:  []string{"get_weather", "get_stock_price"},
+		maxIterations: 10,
 	})
 	assert.NoError(t, err)
 

--- a/llm_provider_aws_bedrock_streaming.go
+++ b/llm_provider_aws_bedrock_streaming.go
@@ -132,11 +132,6 @@ func (p *BedrockLLMProvider) GetStreamingResponse(ctx context.Context, messages 
 		}
 	}
 
-	maxIterations := 10
-	if config.maxIterations > 0 {
-		maxIterations = config.maxIterations
-	}
-
 	go func() {
 		defer close(responseChan)
 
@@ -148,7 +143,7 @@ func (p *BedrockLLMProvider) GetStreamingResponse(ctx context.Context, messages 
 		var currentToolInputBuffer *strings.Builder
 
 	OuterLoop:
-		for turn := 0; turn < maxIterations; turn++ {
+		for turn := 0; turn < config.maxIterations; turn++ {
 
 			currentToolUseID = nil
 			currentToolName = nil
@@ -384,7 +379,7 @@ func (p *BedrockLLMProvider) GetStreamingResponse(ctx context.Context, messages 
 
 		}
 
-		responseChan <- StreamingLLMResponse{Error: fmt.Errorf("streaming: max tool iterations (%d) reached", maxIterations), Done: true}
+		responseChan <- StreamingLLMResponse{Error: fmt.Errorf("streaming: max tool iterations (%d) reached", config.maxIterations), Done: true}
 
 	}()
 

--- a/types.go
+++ b/types.go
@@ -32,7 +32,7 @@ const (
 	DefaultTopK int64 = 40
 
 	// DefaultMaxIterations is the default maximum number of iterations for LLM responses
-	DefaultMaxIterations int = 10
+	DefaultMaxIterations int = 25
 )
 
 // DefaultConfig holds the default values for LLMRequestConfig


### PR DESCRIPTION
Adjusted `maxIterations` to be configurable in streaming responses for both `AnthropicLLMProvider` and `BedrockLLMProvider`. Updated the `DefaultMaxIterations` value from 10 to 25 and modified corresponding test cases to validate the changes. Enhanced iteration-related error messages.