### PR TITLE
feat(anth2oai): OpenAI-compatible facade over Anthropic endpoints

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -34,6 +34,23 @@ jobs:
           VALIDATE_GO: true
           VALIDATE_MARKDOWN: true
 
+  gosec:
+    name: gosec (security scan)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # Non-blocking for now: legacy code has pre-existing findings tracked in
+    # issue #75. This surfaces issues without failing the build.
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run gosec
+        uses: securego/gosec@master
+        with:
+          args: ./...
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,85 @@
+# Pre-commit hooks for goai — https://pre-commit.com
+#
+# Setup (once per clone):
+#   pip install pre-commit    # or: brew install pre-commit
+#   pre-commit install        # install the git hook
+#
+# Run manually:
+#   pre-commit run --all-files
+#
+# The Go hooks use your local `go` toolchain. gofmt + goimports mirror the Go
+# linting CI enforces (.github/linters/.golangci.yml). gitleaks is built from
+# source in an isolated environment by pre-commit, so no system install is needed.
+minimum_pre_commit_version: "3.5.0"
+
+# testdata holds byte-exact SSE/JSON fixtures — never rewrite them.
+exclude: '^anth2oai/testdata/'
+
+repos:
+  # ---- General file hygiene ----
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-added-large-files
+        args: ["--maxkb=1024"]
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: detect-private-key
+      - id: mixed-line-ending
+        args: ["--fix=lf"]
+
+  # ---- Secret scanning (must stay green per CLAUDE.md) ----
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+
+  # ---- Go toolchain checks (local, via installed `go`) ----
+  - repo: local
+    hooks:
+      - id: go-fmt
+        name: go fmt
+        description: Format Go code with gofmt.
+        entry: gofmt -l -w
+        language: system
+        types: [go]
+
+      - id: go-imports
+        name: go imports
+        description: Fix and order imports with goimports (mirrors CI).
+        entry: bash -c 'go run golang.org/x/tools/cmd/goimports@v0.28.0 -l -w "$@"' --
+        language: system
+        types: [go]
+
+      - id: go-vet
+        name: go vet
+        description: Report suspicious constructs with go vet.
+        entry: bash -c 'go vet ./...'
+        language: system
+        types: [go]
+        pass_filenames: false
+
+      - id: go-build
+        name: go build
+        description: Ensure the whole module compiles.
+        entry: bash -c 'go build ./...'
+        language: system
+        types: [go]
+        pass_filenames: false
+
+      # gosec runs on demand only (stages: [manual]) — it is not enforced on
+      # every commit yet because of pre-existing findings in legacy code, which
+      # are tracked in issue #75 for a follow-up fix. Run it explicitly with:
+      #   pre-commit run gosec --hook-stage manual --all-files
+      - id: gosec
+        name: gosec (manual security scan)
+        description: Static security analysis with gosec (report-only for now).
+        entry: bash -c 'go run github.com/securego/gosec/v2/cmd/gosec@v2.27.1 -quiet ./...'
+        language: system
+        types: [go]
+        pass_filenames: false
+        stages: [manual]

--- a/_examples/anth2oai_glm/README.md
+++ b/_examples/anth2oai_glm/README.md
@@ -1,0 +1,29 @@
+# anth2oai — GLM/Z.ai example
+
+Talk to an **Anthropic-format** endpoint (GLM/Z.ai, Kimi, DeepSeek, …) using the
+**OpenAI SDK**, via the [`anth2oai`](../../anth2oai) package.
+
+## Run
+
+```bash
+export ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic
+export ANTHROPIC_AUTH_TOKEN=<your token>
+go run ./_examples/anth2oai_glm
+```
+
+Expected output (content depends on the model):
+
+```
+non-streaming: "OK" (tokens: 23)
+streaming:     one, two, three, four, five
+```
+
+## What it shows
+
+- `anth2oai.New(base, token)` returns a normal `*openai.Client`.
+- `client.Chat.Completions.New(...)` — non-streaming, with a system prompt.
+- `client.Chat.Completions.NewStreaming(...)` — token-by-token streaming.
+
+Nothing is hardcoded: the base URL and token come only from the environment. The
+upstream model id (`glm-4.5-air`) is passed through verbatim — there is no model
+aliasing.

--- a/_examples/anth2oai_glm/main.go
+++ b/_examples/anth2oai_glm/main.go
@@ -1,0 +1,66 @@
+// Command anth2oai_glm demonstrates talking to an Anthropic-format endpoint
+// (e.g. GLM/Z.ai) through the OpenAI SDK, using the anth2oai package.
+//
+// Usage:
+//
+//	export ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic
+//	export ANTHROPIC_AUTH_TOKEN=<your token>
+//	go run ./_examples/anth2oai_glm
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/openai/openai-go"
+	"github.com/shaharia-lab/goai/anth2oai"
+)
+
+const model = "glm-4.5-air"
+
+func main() {
+	base := os.Getenv("ANTHROPIC_BASE_URL")
+	token := os.Getenv("ANTHROPIC_AUTH_TOKEN")
+	if base == "" || token == "" {
+		log.Fatal("set ANTHROPIC_BASE_URL and ANTHROPIC_AUTH_TOKEN")
+	}
+
+	// A normal *openai.Client, wired to the Anthropic endpoint.
+	client := anth2oai.New(base, token)
+	ctx := context.Background()
+
+	// --- Non-streaming ---
+	resp, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+		Model: openai.F(model),
+		Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+			openai.SystemMessage("You are terse."),
+			openai.UserMessage("Reply with exactly: OK"),
+		}),
+	})
+	if err != nil {
+		log.Fatalf("non-streaming request failed: %v", err)
+	}
+	fmt.Printf("non-streaming: %q (tokens: %d)\n",
+		resp.Choices[0].Message.Content, resp.Usage.TotalTokens)
+
+	// --- Streaming ---
+	fmt.Print("streaming:     ")
+	stream := client.Chat.Completions.NewStreaming(ctx, openai.ChatCompletionNewParams{
+		Model: openai.F(model),
+		Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage("Count from one to five, comma separated."),
+		}),
+	})
+	for stream.Next() {
+		chunk := stream.Current()
+		if len(chunk.Choices) > 0 {
+			fmt.Print(chunk.Choices[0].Delta.Content)
+		}
+	}
+	if err := stream.Err(); err != nil {
+		log.Fatalf("\nstreaming request failed: %v", err)
+	}
+	fmt.Println()
+}

--- a/anth2oai/anth2oai.go
+++ b/anth2oai/anth2oai.go
@@ -1,0 +1,24 @@
+package anth2oai
+
+import (
+	"net/http"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+)
+
+// New returns an *openai.Client that speaks the OpenAI Chat Completions API but
+// is wired, through the L2 transport, to an Anthropic Messages endpoint at
+// baseURL. Callers then use the normal OpenAI SDK surface unchanged:
+//
+//	client := anth2oai.New("https://api.z.ai/api/anthropic", token)
+//	resp, err := client.Chat.Completions.New(ctx, params)   // non-streaming
+//	stream   := client.Chat.Completions.NewStreaming(ctx, params) // streaming
+func New(baseURL, apiKey string, opts ...Option) *openai.Client {
+	rt := NewRoundTripper(baseURL, apiKey, opts...)
+	return openai.NewClient(
+		option.WithBaseURL(baseURL),
+		option.WithAPIKey(apiKey),
+		option.WithHTTPClient(&http.Client{Transport: rt}),
+	)
+}

--- a/anth2oai/doc.go
+++ b/anth2oai/doc.go
@@ -1,0 +1,58 @@
+// Package anth2oai turns an Anthropic-format inference endpoint (the Anthropic
+// Messages API, POST /v1/messages) into an OpenAI Chat Completions-compatible
+// one. It lets a caller use the OpenAI SDK — or any OpenAI HTTP client — to talk
+// to providers that only expose an Anthropic-compatible endpoint (Z.ai/GLM,
+// Kimi, DeepSeek, and Claude itself).
+//
+// The name encodes the direction: anth2oai = "expose an Anthropic endpoint
+// through the OpenAI interface".
+//
+// # Layers
+//
+//	L1  pure translators   OpenAI ⇄ Anthropic (request, response, SSE stream)
+//	L2  http.RoundTripper  plugs the translation into any *http.Client / the SDK
+//	L3  New(...)           a *openai.Client preloaded with the L2 transport
+//	L4  NewHandler(...)    an OpenAI-compatible POST /v1/chat/completions proxy
+//
+// # Usage
+//
+//	client := anth2oai.New("https://api.z.ai/api/anthropic", token)
+//	resp, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+//	    Model:    openai.F("glm-4.5-air"),
+//	    Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+//	        openai.UserMessage("Reply with exactly: OK"),
+//	    }),
+//	})
+//
+// Streaming works through the same client via Chat.Completions.NewStreaming.
+//
+// # Auth
+//
+// By default the caller's key is forwarded as "Authorization: Bearer <key>"
+// (validated against Z.ai/GLM) plus an "anthropic-version: 2023-06-01" header.
+// Use WithAuthHeader(AuthXAPIKey) for endpoints that require the native
+// Anthropic "x-api-key" scheme.
+//
+// # Supported OpenAI fields
+//
+//	model, messages (system/developer, user, assistant, tool),
+//	max_tokens / max_completion_tokens, temperature (clamped to [0,1]),
+//	top_p, stop, tools + tool_choice, stream + stream_options.include_usage.
+//	Image parts (image_url) are translated best-effort (data: URIs become
+//	base64 image blocks, http(s) URLs become URL image blocks) and passed
+//	through; upstream support varies.
+//
+// # Unsupported OpenAI fields (ignored in v1)
+//
+//	n > 1 (treated as 1), logit_bias, presence_penalty, frequency_penalty,
+//	seed, response_format, logprobs. No model-name aliasing: the upstream model
+//	id is passed through verbatim. Only Chat Completions is proxied — not
+//	/v1/models, embeddings, or other OpenAI endpoints.
+//
+// # Note on types
+//
+// The translators operate on plain JSON wire structs rather than the SDK
+// "params" types: those wrap fields in helpers that marshal but do not
+// unmarshal, so an inbound OpenAI body cannot be decoded back into them. The
+// official SDK types remain the public boundary (New returns *openai.Client).
+package anth2oai

--- a/anth2oai/doc.go
+++ b/anth2oai/doc.go
@@ -42,6 +42,12 @@
 //	base64 image blocks, http(s) URLs become URL image blocks) and passed
 //	through; upstream support varies.
 //
+// # Behaviors that differ from OpenAI
+//
+// temperature is clamped from OpenAI's 0..2 range to Anthropic's 0..1 (silently;
+// a value of 1.5 becomes 1.0). tool_choice "none" omits the tools entirely.
+// Tool-role message content is flattened to text for the Anthropic tool_result.
+//
 // # Unsupported OpenAI fields (ignored in v1)
 //
 //	n > 1 (treated as 1), logit_bias, presence_penalty, frequency_penalty,

--- a/anth2oai/errors.go
+++ b/anth2oai/errors.go
@@ -1,0 +1,97 @@
+package anth2oai
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+// oaiErrorEnvelope is the OpenAI error response shape: {"error": {...}}.
+type oaiErrorEnvelope struct {
+	Error oaiErrorBody `json:"error"`
+}
+
+type oaiErrorBody struct {
+	Message string  `json:"message"`
+	Type    string  `json:"type"`
+	Code    *string `json:"code"`
+	Param   *string `json:"param"`
+}
+
+// mapAnthropicError translates an upstream Anthropic error body into OpenAI
+// error JSON. It preserves the upstream message and type when present and falls
+// back to the raw body as the message otherwise.
+func mapAnthropicError(status int, body []byte) []byte {
+	env := oaiErrorEnvelope{Error: oaiErrorBody{Type: defaultErrorType(status)}}
+
+	var anthEnv anthErrorEnvelope
+	if err := json.Unmarshal(body, &anthEnv); err == nil && anthEnv.Error != nil && anthEnv.Error.Message != "" {
+		env.Error.Message = anthEnv.Error.Message
+		if anthEnv.Error.Type != "" {
+			env.Error.Type = anthEnv.Error.Type
+		}
+	} else if trimmed := bytes.TrimSpace(body); len(trimmed) > 0 {
+		env.Error.Message = string(trimmed)
+	} else {
+		env.Error.Message = http.StatusText(status)
+	}
+
+	out, err := json.Marshal(env)
+	if err != nil {
+		return []byte(`{"error":{"message":"upstream error","type":"api_error"}}`)
+	}
+	return out
+}
+
+// defaultErrorType maps an HTTP status to an OpenAI-style error type.
+func defaultErrorType(status int) string {
+	switch status {
+	case http.StatusUnauthorized:
+		return "authentication_error"
+	case http.StatusForbidden:
+		return "permission_error"
+	case http.StatusNotFound:
+		return "not_found_error"
+	case http.StatusTooManyRequests:
+		return "rate_limit_error"
+	case http.StatusBadRequest, http.StatusUnprocessableEntity:
+		return "invalid_request_error"
+	default:
+		if status >= 500 {
+			return "api_error"
+		}
+		return "invalid_request_error"
+	}
+}
+
+// newErrorBody builds an OpenAI error JSON body from scratch.
+func newErrorBody(message, errType string) []byte {
+	out, err := json.Marshal(oaiErrorEnvelope{Error: oaiErrorBody{Message: message, Type: errType}})
+	if err != nil {
+		return []byte(`{"error":{"message":"internal error","type":"api_error"}}`)
+	}
+	return out
+}
+
+// errorResponse constructs an *http.Response carrying an OpenAI error body.
+func errorResponse(req *http.Request, status int, body []byte) *http.Response {
+	return jsonResponse(req, status, body)
+}
+
+// jsonResponse builds an *http.Response with a JSON body.
+func jsonResponse(req *http.Request, status int, body []byte) *http.Response {
+	h := make(http.Header)
+	h.Set("Content-Type", "application/json")
+	return &http.Response{
+		StatusCode:    status,
+		Status:        http.StatusText(status),
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        h,
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+		Request:       req,
+	}
+}

--- a/anth2oai/example_test.go
+++ b/anth2oai/example_test.go
@@ -1,0 +1,147 @@
+package anth2oai_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+
+	"github.com/openai/openai-go"
+	"github.com/shaharia-lab/goai/anth2oai"
+)
+
+// Example shows the core use: drive an Anthropic-format endpoint with the normal
+// OpenAI SDK. A stub HTTP server stands in for the real upstream (e.g.
+// https://api.z.ai/api/anthropic) so the example is self-contained and runnable.
+func Example() {
+	// Stand-in for the Anthropic upstream: replies with an Anthropic Message.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"msg_1","type":"message","role":"assistant","model":"glm-4.5-air",`+
+			`"content":[{"type":"text","text":"OK"}],"stop_reason":"end_turn",`+
+			`"usage":{"input_tokens":8,"output_tokens":1}}`)
+	}))
+	defer upstream.Close()
+
+	// New returns a plain *openai.Client wired to the Anthropic endpoint.
+	client := anth2oai.New(upstream.URL, "test-key")
+
+	resp, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
+		Model: openai.F("glm-4.5-air"),
+		Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage("Reply with exactly: OK"),
+		}),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(resp.Choices[0].Message.Content)
+	// Output: OK
+}
+
+// ExampleNew is the idiomatic real-world call against a live GLM/Z.ai endpoint,
+// with the upstream model id passed through verbatim.
+func ExampleNew() {
+	client := anth2oai.New("https://api.z.ai/api/anthropic", os.Getenv("ANTHROPIC_AUTH_TOKEN"))
+
+	resp, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
+		Model: openai.F("glm-4.5-air"),
+		Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+			openai.SystemMessage("You are terse."),
+			openai.UserMessage("Reply with exactly: OK"),
+		}),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(resp.Choices[0].Message.Content)
+}
+
+// ExampleNew_streaming streams tokens through the same OpenAI SDK surface.
+func ExampleNew_streaming() {
+	client := anth2oai.New("https://api.z.ai/api/anthropic", os.Getenv("ANTHROPIC_AUTH_TOKEN"))
+
+	stream := client.Chat.Completions.NewStreaming(context.Background(), openai.ChatCompletionNewParams{
+		Model: openai.F("glm-4.5-air"),
+		Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage("Count from one to five."),
+		}),
+	})
+	defer stream.Close()
+
+	for stream.Next() {
+		chunk := stream.Current()
+		if len(chunk.Choices) > 0 {
+			fmt.Print(chunk.Choices[0].Delta.Content)
+		}
+	}
+	if err := stream.Err(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// ExampleNew_tools shows tool/function calling: the OpenAI tool definition is
+// translated to an Anthropic tool, and tool_use results come back as tool_calls.
+func ExampleNew_tools() {
+	client := anth2oai.New("https://api.z.ai/api/anthropic", os.Getenv("ANTHROPIC_AUTH_TOKEN"))
+
+	resp, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
+		Model: openai.F("glm-4.5-air"),
+		Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage("What is the weather in Paris?"),
+		}),
+		Tools: openai.F([]openai.ChatCompletionToolParam{{
+			Type: openai.F(openai.ChatCompletionToolTypeFunction),
+			Function: openai.F(openai.FunctionDefinitionParam{
+				Name:        openai.F("get_weather"),
+				Description: openai.F("Get the current weather for a location"),
+				Parameters: openai.F(openai.FunctionParameters{
+					"type":       "object",
+					"properties": map[string]any{"location": map[string]any{"type": "string"}},
+					"required":   []string{"location"},
+				}),
+			}),
+		}}),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, call := range resp.Choices[0].Message.ToolCalls {
+		fmt.Printf("%s(%s)\n", call.Function.Name, call.Function.Arguments)
+	}
+}
+
+// ExampleNewRoundTripper plugs the translation into a bare *http.Client, without
+// the OpenAI SDK. The client then speaks OpenAI Chat Completions to the upstream.
+func ExampleNewRoundTripper() {
+	rt := anth2oai.NewRoundTripper("https://api.z.ai/api/anthropic", os.Getenv("ANTHROPIC_AUTH_TOKEN"))
+	httpClient := &http.Client{Transport: rt}
+
+	// POST an OpenAI-shaped body to any path ending in /chat/completions.
+	_ = httpClient
+}
+
+// ExampleNewHandler exposes the Anthropic endpoint as an OpenAI-compatible HTTP
+// proxy, so non-Go clients can reach it.
+func ExampleNewHandler() {
+	handler := anth2oai.NewHandler("https://api.z.ai/api/anthropic", os.Getenv("ANTHROPIC_AUTH_TOKEN"))
+
+	mux := http.NewServeMux()
+	mux.Handle("/v1/chat/completions", handler)
+	log.Fatal(http.ListenAndServe(":8080", mux))
+}
+
+// ExampleWithAuthHeader targets an endpoint that requires the native Anthropic
+// "x-api-key" scheme instead of the default Bearer token, and raises the default
+// max_tokens.
+func ExampleWithAuthHeader() {
+	client := anth2oai.New(
+		"https://api.anthropic.com",
+		os.Getenv("ANTHROPIC_API_KEY"),
+		anth2oai.WithAuthHeader(anth2oai.AuthXAPIKey),
+		anth2oai.WithDefaultMaxTokens(1024),
+	)
+	_ = client
+}

--- a/anth2oai/handler.go
+++ b/anth2oai/handler.go
@@ -1,0 +1,102 @@
+package anth2oai
+
+import (
+	"net/http"
+	"strings"
+)
+
+// NewHandler builds an http.Handler (the L4 proxy) that accepts OpenAI Chat
+// Completions requests on POST /v1/chat/completions and forwards them, through
+// the L2 transport, to the Anthropic endpoint at baseURL — reusing all of the
+// translation logic verbatim.
+func NewHandler(baseURL, apiKey string, opts ...Option) http.Handler {
+	cfg := newConfig(baseURL, apiKey, opts...)
+	return &handler{
+		rt:  NewRoundTripper(baseURL, apiKey, opts...),
+		cfg: cfg,
+	}
+}
+
+type handler struct {
+	rt  http.RoundTripper
+	cfg *config
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed,
+			newErrorBody("method not allowed; use POST", "invalid_request_error"))
+		return
+	}
+	if !isChatCompletionsPath(r.URL.Path) {
+		writeJSON(w, http.StatusNotFound,
+			newErrorBody("unknown route; POST /v1/chat/completions", "not_found_error"))
+		return
+	}
+	defer func() {
+		if r.Body != nil {
+			_ = r.Body.Close()
+		}
+	}()
+
+	// Route through the L2 transport. The transport builds its own upstream URL
+	// from the configured baseURL, so only the path (checked here) matters.
+	upReq, err := http.NewRequestWithContext(r.Context(), http.MethodPost,
+		"http://anth2oai.local/v1/chat/completions", r.Body)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError,
+			newErrorBody("internal error: "+err.Error(), "api_error"))
+		return
+	}
+	upReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := h.rt.RoundTrip(upReq)
+	if err != nil {
+		h.cfg.logger.WithFields(map[string]interface{}{"error": err.Error()}).
+			Error("anth2oai: handler upstream error")
+		writeJSON(w, http.StatusBadGateway,
+			newErrorBody("upstream error: "+err.Error(), "api_error"))
+		return
+	}
+	defer resp.Body.Close()
+
+	copyResponse(w, resp)
+}
+
+// copyResponse streams resp to w, flushing after each write so SSE frames reach
+// the client incrementally.
+func copyResponse(w http.ResponseWriter, resp *http.Response) {
+	for k, vv := range resp.Header {
+		for _, v := range vv {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+
+	flusher, _ := w.(http.Flusher)
+	buf := make([]byte, 16*1024)
+	for {
+		n, err := resp.Body.Read(buf)
+		if n > 0 {
+			if _, werr := w.Write(buf[:n]); werr != nil {
+				return
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, body []byte) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
+}
+
+func isChatCompletionsPath(p string) bool {
+	return strings.HasSuffix(strings.TrimRight(p, "/"), "chat/completions")
+}

--- a/anth2oai/handler.go
+++ b/anth2oai/handler.go
@@ -12,7 +12,7 @@ import (
 func NewHandler(baseURL, apiKey string, opts ...Option) http.Handler {
 	cfg := newConfig(baseURL, apiKey, opts...)
 	return &handler{
-		rt:  NewRoundTripper(baseURL, apiKey, opts...),
+		rt:  newRoundTripper(cfg),
 		cfg: cfg,
 	}
 }

--- a/anth2oai/handler_test.go
+++ b/anth2oai/handler_test.go
@@ -1,0 +1,78 @@
+package anth2oai
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandler_NonStreaming(t *testing.T) {
+	stub := &stubTransport{
+		respond: func(_ *http.Request, _ []byte) (*http.Response, error) {
+			return newResp(200, "application/json", `{
+				"id":"msg_h","type":"message","role":"assistant","model":"m",
+				"content":[{"type":"text","text":"hello"}],
+				"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}
+			}`), nil
+		},
+	}
+	h := NewHandler("https://up.example", "k", WithBaseTransport(stub))
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/v1/chat/completions", "application/json",
+		strings.NewReader(`{"model":"m","messages":[{"role":"user","content":"hi"}]}`))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var out oaiResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	require.NotNil(t, out.Choices[0].Message.Content)
+	assert.Equal(t, "hello", *out.Choices[0].Message.Content)
+}
+
+func TestHandler_Streaming(t *testing.T) {
+	sse, err := os.ReadFile("testdata/text_stream.sse")
+	require.NoError(t, err)
+	stub := &stubTransport{
+		respond: func(_ *http.Request, _ []byte) (*http.Response, error) {
+			return newResp(200, "text/event-stream", string(sse)), nil
+		},
+	}
+	h := NewHandler("https://up.example", "k", WithBaseTransport(stub))
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/v1/chat/completions", "application/json",
+		strings.NewReader(`{"model":"m","messages":[{"role":"user","content":"hi"}],"stream":true}`))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	out := string(body)
+	assert.Contains(t, out, `"content":"O"`)
+	assert.True(t, strings.HasSuffix(strings.TrimSpace(out), "data: [DONE]"))
+}
+
+func TestHandler_MethodNotAllowed(t *testing.T) {
+	h := NewHandler("https://up.example", "k", WithBaseTransport(&stubTransport{
+		respond: func(_ *http.Request, _ []byte) (*http.Response, error) { return nil, nil },
+	}))
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/v1/chat/completions")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+}

--- a/anth2oai/integration_test.go
+++ b/anth2oai/integration_test.go
@@ -1,0 +1,160 @@
+//go:build integration
+
+// Package anth2oai live integration tests. These run against a real
+// Anthropic-format endpoint (validated with GLM/Z.ai) and are skipped unless
+// both ANTHROPIC_BASE_URL and ANTHROPIC_AUTH_TOKEN are set.
+//
+// Run locally after exporting your credentials, e.g.:
+//
+//	export ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic
+//	export ANTHROPIC_AUTH_TOKEN=<your token>
+//	go test -tags=integration ./anth2oai/...
+//
+// The test never reads any settings file — credentials come only from the
+// environment.
+package anth2oai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const integrationModel = "glm-4.5-air"
+
+func integrationCreds(t *testing.T) (base, token string) {
+	t.Helper()
+	base = os.Getenv("ANTHROPIC_BASE_URL")
+	token = os.Getenv("ANTHROPIC_AUTH_TOKEN")
+	if base == "" || token == "" {
+		t.Skip("set ANTHROPIC_BASE_URL and ANTHROPIC_AUTH_TOKEN to run integration tests")
+	}
+	return base, token
+}
+
+func TestIntegration_NonStreaming(t *testing.T) {
+	base, token := integrationCreds(t)
+	client := New(base, token)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	resp, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+		Model: openai.F(integrationModel),
+		Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage("Reply with exactly: OK"),
+		}),
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	assert.NotEmpty(t, resp.Choices[0].Message.Content)
+	assert.NotZero(t, resp.Usage.TotalTokens)
+}
+
+func TestIntegration_Streaming(t *testing.T) {
+	base, token := integrationCreds(t)
+	client := New(base, token)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	stream := client.Chat.Completions.NewStreaming(ctx, openai.ChatCompletionNewParams{
+		Model: openai.F(integrationModel),
+		Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage("Count to three."),
+		}),
+	})
+	defer stream.Close()
+
+	var content, finish string
+	for stream.Next() {
+		chunk := stream.Current()
+		if len(chunk.Choices) == 0 {
+			continue
+		}
+		content += chunk.Choices[0].Delta.Content
+		if chunk.Choices[0].FinishReason != "" {
+			finish = string(chunk.Choices[0].FinishReason)
+		}
+	}
+	require.NoError(t, stream.Err())
+	assert.NotEmpty(t, content)
+	assert.NotEmpty(t, finish)
+}
+
+func TestIntegration_ToolCall(t *testing.T) {
+	base, token := integrationCreds(t)
+	client := New(base, token)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	resp, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+		Model: openai.F(integrationModel),
+		Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage("What is the weather in Paris? Use the tool."),
+		}),
+		Tools: openai.F([]openai.ChatCompletionToolParam{{
+			Type: openai.F(openai.ChatCompletionToolTypeFunction),
+			Function: openai.F(openai.FunctionDefinitionParam{
+				Name:        openai.F("get_weather"),
+				Description: openai.F("Get the current weather for a location"),
+				Parameters: openai.F(openai.FunctionParameters{
+					"type":       "object",
+					"properties": map[string]any{"location": map[string]any{"type": "string"}},
+					"required":   []string{"location"},
+				}),
+			}),
+		}}),
+		ToolChoice: openai.F[openai.ChatCompletionToolChoiceOptionUnionParam](
+			openai.ChatCompletionToolChoiceOptionAutoRequired),
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	require.NotEmpty(t, resp.Choices[0].Message.ToolCalls)
+	call := resp.Choices[0].Message.ToolCalls[0]
+	assert.Equal(t, "get_weather", call.Function.Name)
+	var args map[string]any
+	assert.NoError(t, json.Unmarshal([]byte(call.Function.Arguments), &args), "arguments must be valid JSON")
+}
+
+func TestIntegration_Handler(t *testing.T) {
+	base, token := integrationCreds(t)
+	srv := httptest.NewServer(NewHandler(base, token))
+	defer srv.Close()
+
+	// Non-streaming through the proxy handler.
+	resp, err := http.Post(srv.URL+"/v1/chat/completions", "application/json", strings.NewReader(`{
+		"model":"`+integrationModel+`",
+		"messages":[{"role":"user","content":"Reply with exactly: OK"}]
+	}`))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, 200, resp.StatusCode)
+	var out map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	assert.Equal(t, "chat.completion", out["object"])
+
+	// Streaming through the proxy handler.
+	sresp, err := http.Post(srv.URL+"/v1/chat/completions", "application/json", strings.NewReader(`{
+		"model":"`+integrationModel+`",
+		"messages":[{"role":"user","content":"Count to three."}],
+		"stream":true
+	}`))
+	require.NoError(t, err)
+	defer sresp.Body.Close()
+	body, err := io.ReadAll(sresp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "chat.completion.chunk")
+	assert.Contains(t, string(body), "data: [DONE]")
+}

--- a/anth2oai/options.go
+++ b/anth2oai/options.go
@@ -62,6 +62,14 @@ func newConfig(baseURL, apiKey string, opts ...Option) *config {
 	if c.anthropicVersion == "" {
 		c.anthropicVersion = defaultAnthropicHeader
 	}
+	// Surface misconfiguration at construction rather than deep inside a request.
+	// The constructors return concrete types (not errors), so we warn rather than fail.
+	if c.baseURL == "" {
+		c.logger.Warn("anth2oai: empty baseURL; upstream requests will fail")
+	}
+	if c.apiKey == "" {
+		c.logger.Warn("anth2oai: empty apiKey; the upstream will reject requests")
+	}
 	return c
 }
 

--- a/anth2oai/options.go
+++ b/anth2oai/options.go
@@ -1,0 +1,116 @@
+package anth2oai
+
+import (
+	"net/http"
+
+	"github.com/shaharia-lab/goai"
+)
+
+// AuthKind selects how the upstream credential is presented to the Anthropic endpoint.
+type AuthKind int
+
+const (
+	// AuthBearer sends the credential as "Authorization: Bearer <apiKey>".
+	// This is the default and is validated against GLM/Z.ai's Anthropic endpoint,
+	// which Claude Code reaches via ANTHROPIC_AUTH_TOKEN as a bearer token.
+	AuthBearer AuthKind = iota
+	// AuthXAPIKey sends the credential as "x-api-key: <apiKey>", the native
+	// Anthropic authentication scheme. Use it for providers that require it.
+	AuthXAPIKey
+)
+
+const (
+	defaultMaxTokens       int64  = 4096
+	defaultAnthropicHeader string = "2023-06-01"
+)
+
+// config holds the resolved settings for a RoundTripper / client / handler.
+type config struct {
+	baseURL          string
+	apiKey           string
+	defaultMaxTokens int64
+	anthropicVersion string
+	authKind         AuthKind
+	httpClient       *http.Client
+	baseTransport    http.RoundTripper
+	logger           goai.Logger
+}
+
+// Option customises a config using the functional-options pattern used across goai.
+type Option func(*config)
+
+func newConfig(baseURL, apiKey string, opts ...Option) *config {
+	c := &config{
+		baseURL:          baseURL,
+		apiKey:           apiKey,
+		defaultMaxTokens: defaultMaxTokens,
+		anthropicVersion: defaultAnthropicHeader,
+		authKind:         AuthBearer,
+		logger:           goai.NewNullLogger(),
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(c)
+		}
+	}
+	if c.logger == nil {
+		c.logger = goai.NewNullLogger()
+	}
+	if c.defaultMaxTokens <= 0 {
+		c.defaultMaxTokens = defaultMaxTokens
+	}
+	if c.anthropicVersion == "" {
+		c.anthropicVersion = defaultAnthropicHeader
+	}
+	return c
+}
+
+// nextTransport resolves the http.RoundTripper used to reach the upstream.
+func (c *config) nextTransport() http.RoundTripper {
+	if c.baseTransport != nil {
+		return c.baseTransport
+	}
+	if c.httpClient != nil && c.httpClient.Transport != nil {
+		return c.httpClient.Transport
+	}
+	return http.DefaultTransport
+}
+
+// WithDefaultMaxTokens sets the max_tokens value applied when the OpenAI caller
+// omits both max_tokens and max_completion_tokens. Anthropic requires max_tokens.
+func WithDefaultMaxTokens(n int) Option {
+	return func(c *config) {
+		if n > 0 {
+			c.defaultMaxTokens = int64(n)
+		}
+	}
+}
+
+// WithAnthropicVersion overrides the "anthropic-version" header (default 2023-06-01).
+func WithAnthropicVersion(v string) Option {
+	return func(c *config) { c.anthropicVersion = v }
+}
+
+// WithAuthHeader selects the upstream authentication scheme (Bearer default, or x-api-key).
+func WithAuthHeader(kind AuthKind) Option {
+	return func(c *config) { c.authKind = kind }
+}
+
+// WithHTTPClient sets the underlying *http.Client whose Transport is used for
+// upstream calls. Only its Transport is consumed; timeouts/redirect policy are
+// governed by the client the caller drives (e.g. the OpenAI SDK client).
+func WithHTTPClient(client *http.Client) Option {
+	return func(c *config) { c.httpClient = client }
+}
+
+// WithLogger sets the goai.Logger. A null logger is used by default.
+func WithLogger(l goai.Logger) Option {
+	return func(c *config) { c.logger = l }
+}
+
+// WithBaseTransport sets the http.RoundTripper used to reach the upstream,
+// bypassing WithHTTPClient. Intended for testing and composition (e.g. a stub
+// transport returning canned Anthropic responses).
+func WithBaseTransport(rt http.RoundTripper) Option {
+	return func(c *config) { c.baseTransport = rt }
+}

--- a/anth2oai/options.go
+++ b/anth2oai/options.go
@@ -36,7 +36,9 @@ type config struct {
 	logger           goai.Logger
 }
 
-// Option customises a config using the functional-options pattern used across goai.
+// Option customises the client, transport, or handler built by New,
+// NewRoundTripper, or NewHandler, following the functional-options pattern used
+// across goai.
 type Option func(*config)
 
 func newConfig(baseURL, apiKey string, opts ...Option) *config {

--- a/anth2oai/testdata/text_stream.sse
+++ b/anth2oai/testdata/text_stream.sse
@@ -1,0 +1,24 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_text_1","type":"message","role":"assistant","model":"glm-4.5-air","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":12,"output_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: ping
+data: {"type":"ping"}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"O"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"K"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}
+
+event: message_stop
+data: {"type":"message_stop"}
+

--- a/anth2oai/testdata/tool_stream.sse
+++ b/anth2oai/testdata/tool_stream.sse
@@ -1,0 +1,21 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_tool_1","type":"message","role":"assistant","model":"glm-4.5-air","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":20,"output_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_abc","name":"get_weather","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"location\":"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"Paris\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":15}}
+
+event: message_stop
+data: {"type":"message_stop"}
+

--- a/anth2oai/translate_request.go
+++ b/anth2oai/translate_request.go
@@ -1,0 +1,315 @@
+package anth2oai
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// emptyObject is the default Anthropic tool input schema / tool_use input.
+var emptyObject = json.RawMessage(`{}`)
+
+// defaultInputSchema is used when an OpenAI tool omits its parameters.
+var defaultInputSchema = json.RawMessage(`{"type":"object"}`)
+
+// translateRequest converts a decoded OpenAI Chat Completions request into an
+// Anthropic Messages request. It is pure: no I/O, no globals mutated.
+func translateRequest(in *oaiRequest, defaultMaxTokens int64) (*anthRequest, error) {
+	out := &anthRequest{
+		Model:  in.Model,
+		Stream: in.Stream,
+	}
+
+	// max_tokens: Anthropic requires it.
+	switch {
+	case in.MaxTokens != nil && *in.MaxTokens > 0:
+		out.MaxTokens = *in.MaxTokens
+	case in.MaxCompletionTokens != nil && *in.MaxCompletionTokens > 0:
+		out.MaxTokens = *in.MaxCompletionTokens
+	default:
+		out.MaxTokens = defaultMaxTokens
+	}
+
+	// temperature: OpenAI 0..2, Anthropic 0..1 — clamp.
+	if in.Temperature != nil {
+		t := *in.Temperature
+		if t < 0 {
+			t = 0
+		}
+		if t > 1 {
+			t = 1
+		}
+		out.Temperature = &t
+	}
+	if in.TopP != nil {
+		out.TopP = in.TopP
+	}
+
+	// stop → stop_sequences.
+	stops, err := normalizeStop(in.Stop)
+	if err != nil {
+		return nil, err
+	}
+	out.StopSequences = stops
+
+	// messages.
+	if err := translateMessages(in.Messages, out); err != nil {
+		return nil, err
+	}
+
+	// tools + tool_choice.
+	dropTools, err := translateToolChoice(in.ToolChoice, out)
+	if err != nil {
+		return nil, err
+	}
+	if !dropTools {
+		out.Tools = translateTools(in.Tools)
+	}
+
+	return out, nil
+}
+
+func normalizeStop(raw json.RawMessage) ([]string, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var one string
+	if err := json.Unmarshal(raw, &one); err == nil {
+		if one == "" {
+			return nil, nil
+		}
+		return []string{one}, nil
+	}
+	var many []string
+	if err := json.Unmarshal(raw, &many); err == nil {
+		return many, nil
+	}
+	return nil, fmt.Errorf("anth2oai: invalid stop value: %s", string(raw))
+}
+
+// translateMessages maps OpenAI messages onto Anthropic system text + a message
+// list, merging consecutive same-role blocks into one MessageParam (Anthropic
+// rejects adjacent same-role messages, and tool results must live in a user
+// message).
+func translateMessages(msgs []oaiMessage, out *anthRequest) error {
+	for _, m := range msgs {
+		switch m.Role {
+		case "system", "developer":
+			text, err := messageText(m.Content)
+			if err != nil {
+				return err
+			}
+			if text != "" {
+				out.System = append(out.System, anthTextBlock{Type: "text", Text: text})
+			}
+
+		case "user":
+			blocks, err := userContentBlocks(m.Content)
+			if err != nil {
+				return err
+			}
+			appendBlocks(&out.Messages, "user", blocks)
+
+		case "tool":
+			content := m.Content
+			if len(content) == 0 || string(content) == "null" {
+				content = json.RawMessage(`""`)
+			}
+			block := anthContentBlock{
+				Type:      "tool_result",
+				ToolUseID: m.ToolCallID,
+				Content:   content,
+			}
+			appendBlocks(&out.Messages, "user", []anthContentBlock{block})
+
+		case "assistant":
+			var blocks []anthContentBlock
+			text, err := messageText(m.Content)
+			if err != nil {
+				return err
+			}
+			if text != "" {
+				blocks = append(blocks, anthContentBlock{Type: "text", Text: text})
+			}
+			for _, tc := range m.ToolCalls {
+				input := json.RawMessage(strings.TrimSpace(tc.Function.Arguments))
+				if len(input) == 0 {
+					input = emptyObject
+				}
+				blocks = append(blocks, anthContentBlock{
+					Type:  "tool_use",
+					ID:    tc.ID,
+					Name:  tc.Function.Name,
+					Input: input,
+				})
+			}
+			appendBlocks(&out.Messages, "assistant", blocks)
+
+		default:
+			return fmt.Errorf("anth2oai: unsupported message role: %q", m.Role)
+		}
+	}
+	return nil
+}
+
+// appendBlocks appends blocks to the message list, merging into the previous
+// message when it shares the role.
+func appendBlocks(messages *[]anthMessage, role string, blocks []anthContentBlock) {
+	if len(blocks) == 0 {
+		return
+	}
+	n := len(*messages)
+	if n > 0 && (*messages)[n-1].Role == role {
+		(*messages)[n-1].Content = append((*messages)[n-1].Content, blocks...)
+		return
+	}
+	*messages = append(*messages, anthMessage{Role: role, Content: blocks})
+}
+
+// messageText extracts the plain text of an OpenAI message content that is
+// either a JSON string or an array of parts (text parts concatenated).
+func messageText(raw json.RawMessage) (string, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return "", nil
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s, nil
+	}
+	var parts []oaiContentPart
+	if err := json.Unmarshal(raw, &parts); err != nil {
+		return "", fmt.Errorf("anth2oai: invalid message content: %w", err)
+	}
+	var b strings.Builder
+	for _, p := range parts {
+		if p.Type == "text" || p.Text != "" {
+			b.WriteString(p.Text)
+		}
+	}
+	return b.String(), nil
+}
+
+// userContentBlocks maps an OpenAI user message content to Anthropic blocks,
+// handling text and image_url parts.
+func userContentBlocks(raw json.RawMessage) ([]anthContentBlock, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		if s == "" {
+			return nil, nil
+		}
+		return []anthContentBlock{{Type: "text", Text: s}}, nil
+	}
+	var parts []oaiContentPart
+	if err := json.Unmarshal(raw, &parts); err != nil {
+		return nil, fmt.Errorf("anth2oai: invalid user content: %w", err)
+	}
+	var blocks []anthContentBlock
+	for _, p := range parts {
+		switch {
+		case p.Type == "image_url" && p.ImageURL != nil:
+			blocks = append(blocks, imageBlock(p.ImageURL.URL))
+		case p.Type == "text" || p.Text != "":
+			blocks = append(blocks, anthContentBlock{Type: "text", Text: p.Text})
+		}
+	}
+	return blocks, nil
+}
+
+// imageBlock converts an OpenAI image_url into an Anthropic image block. A
+// data: URI becomes a base64 source; any other URL becomes a URL source.
+func imageBlock(u string) anthContentBlock {
+	if strings.HasPrefix(u, "data:") {
+		if mediaType, data, ok := parseDataURI(u); ok {
+			return anthContentBlock{
+				Type: "image",
+				Source: &anthImageSource{
+					Type:      "base64",
+					MediaType: mediaType,
+					Data:      data,
+				},
+			}
+		}
+	}
+	return anthContentBlock{
+		Type:   "image",
+		Source: &anthImageSource{Type: "url", URL: u},
+	}
+}
+
+// parseDataURI splits a "data:<mediatype>;base64,<data>" URI.
+func parseDataURI(u string) (mediaType, data string, ok bool) {
+	rest := strings.TrimPrefix(u, "data:")
+	comma := strings.IndexByte(rest, ',')
+	if comma < 0 {
+		return "", "", false
+	}
+	meta, payload := rest[:comma], rest[comma+1:]
+	if !strings.Contains(meta, "base64") {
+		return "", "", false
+	}
+	mediaType = strings.TrimSuffix(meta, ";base64")
+	mediaType = strings.TrimSuffix(mediaType, "base64")
+	mediaType = strings.TrimSuffix(mediaType, ";")
+	if mediaType == "" {
+		mediaType = "image/png"
+	}
+	return mediaType, payload, true
+}
+
+func translateTools(tools []oaiTool) []anthTool {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]anthTool, 0, len(tools))
+	for _, t := range tools {
+		if t.Type != "" && t.Type != "function" {
+			continue
+		}
+		schema := t.Function.Parameters
+		if len(schema) == 0 || string(schema) == "null" {
+			schema = defaultInputSchema
+		}
+		out = append(out, anthTool{
+			Name:        t.Function.Name,
+			Description: t.Function.Description,
+			InputSchema: schema,
+		})
+	}
+	return out
+}
+
+// translateToolChoice maps OpenAI tool_choice onto Anthropic tool_choice.
+// It returns dropTools=true when tools should be omitted entirely ("none").
+func translateToolChoice(raw json.RawMessage, out *anthRequest) (dropTools bool, err error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return false, nil
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		switch s {
+		case "auto":
+			out.ToolChoice = &anthToolChoice{Type: "auto"}
+		case "required":
+			out.ToolChoice = &anthToolChoice{Type: "any"}
+		case "none":
+			return true, nil
+		}
+		return false, nil
+	}
+	var obj struct {
+		Type     string `json:"type"`
+		Function struct {
+			Name string `json:"name"`
+		} `json:"function"`
+	}
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return false, fmt.Errorf("anth2oai: invalid tool_choice: %w", err)
+	}
+	if obj.Function.Name != "" {
+		out.ToolChoice = &anthToolChoice{Type: "tool", Name: obj.Function.Name}
+	}
+	return false, nil
+}

--- a/anth2oai/translate_request.go
+++ b/anth2oai/translate_request.go
@@ -111,9 +111,16 @@ func translateMessages(msgs []oaiMessage, out *anthRequest) error {
 			appendBlocks(&out.Messages, "user", blocks)
 
 		case "tool":
-			content := m.Content
-			if len(content) == 0 || string(content) == "null" {
-				content = json.RawMessage(`""`)
+			// Normalize to a JSON string: OpenAI tool content may be a plain
+			// string or an array of content parts; Anthropic's tool_result takes
+			// a string (or blocks), so we flatten to text either way.
+			text, err := messageText(m.Content)
+			if err != nil {
+				return err
+			}
+			content, err := json.Marshal(text)
+			if err != nil {
+				return fmt.Errorf("anth2oai: encoding tool result: %w", err)
 			}
 			block := anthContentBlock{
 				Type:      "tool_result",

--- a/anth2oai/translate_request_test.go
+++ b/anth2oai/translate_request_test.go
@@ -191,6 +191,23 @@ func TestTranslateRequest_MergesConsecutiveToolResults(t *testing.T) {
 	assert.Len(t, out.Messages[0].Content, 2)
 }
 
+func TestTranslateRequest_ToolResultArrayContent(t *testing.T) {
+	// OpenAI's array content form for a tool result is flattened to a JSON string.
+	in := decodeOAIRequest(t, `{
+		"model":"m",
+		"messages":[{"role":"tool","tool_call_id":"c","content":[
+			{"type":"text","text":"18"},
+			{"type":"text","text":"C"}
+		]}]
+	}`)
+	out, err := translateRequest(in, 4096)
+	require.NoError(t, err)
+	require.Len(t, out.Messages, 1)
+	tr := out.Messages[0].Content[0]
+	assert.Equal(t, "tool_result", tr.Type)
+	assert.JSONEq(t, `"18C"`, string(tr.Content))
+}
+
 func TestTranslateRequest_ImageParts(t *testing.T) {
 	in := decodeOAIRequest(t, `{
 		"model":"m",

--- a/anth2oai/translate_request_test.go
+++ b/anth2oai/translate_request_test.go
@@ -1,0 +1,242 @@
+package anth2oai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func decodeOAIRequest(t *testing.T, body string) *oaiRequest {
+	t.Helper()
+	var r oaiRequest
+	require.NoError(t, json.Unmarshal([]byte(body), &r))
+	return &r
+}
+
+func TestTranslateRequest_Basic(t *testing.T) {
+	in := decodeOAIRequest(t, `{
+		"model": "glm-4.5-air",
+		"messages": [
+			{"role": "system", "content": "You are terse."},
+			{"role": "developer", "content": "Be exact."},
+			{"role": "user", "content": "Reply with exactly: OK"}
+		],
+		"max_tokens": 64,
+		"temperature": 1.5,
+		"top_p": 0.9,
+		"stop": "STOP"
+	}`)
+
+	out, err := translateRequest(in, 4096)
+	require.NoError(t, err)
+
+	assert.Equal(t, "glm-4.5-air", out.Model)
+	assert.Equal(t, int64(64), out.MaxTokens)
+	require.NotNil(t, out.Temperature)
+	assert.Equal(t, 1.0, *out.Temperature, "temperature clamped to [0,1]")
+	require.NotNil(t, out.TopP)
+	assert.Equal(t, 0.9, *out.TopP)
+	assert.Equal(t, []string{"STOP"}, out.StopSequences)
+
+	require.Len(t, out.System, 2)
+	assert.Equal(t, "You are terse.", out.System[0].Text)
+	assert.Equal(t, "Be exact.", out.System[1].Text)
+
+	require.Len(t, out.Messages, 1)
+	assert.Equal(t, "user", out.Messages[0].Role)
+	require.Len(t, out.Messages[0].Content, 1)
+	assert.Equal(t, "text", out.Messages[0].Content[0].Type)
+	assert.Equal(t, "Reply with exactly: OK", out.Messages[0].Content[0].Text)
+}
+
+func TestTranslateRequest_DefaultMaxTokens(t *testing.T) {
+	in := decodeOAIRequest(t, `{"model":"m","messages":[{"role":"user","content":"hi"}]}`)
+	out, err := translateRequest(in, 4096)
+	require.NoError(t, err)
+	assert.Equal(t, int64(4096), out.MaxTokens)
+}
+
+func TestTranslateRequest_MaxCompletionTokensFallback(t *testing.T) {
+	in := decodeOAIRequest(t, `{"model":"m","messages":[{"role":"user","content":"hi"}],"max_completion_tokens":128}`)
+	out, err := translateRequest(in, 4096)
+	require.NoError(t, err)
+	assert.Equal(t, int64(128), out.MaxTokens)
+}
+
+func TestTranslateRequest_TemperatureClampLow(t *testing.T) {
+	in := decodeOAIRequest(t, `{"model":"m","messages":[{"role":"user","content":"hi"}],"temperature":-0.5}`)
+	out, err := translateRequest(in, 4096)
+	require.NoError(t, err)
+	require.NotNil(t, out.Temperature)
+	assert.Equal(t, 0.0, *out.Temperature)
+}
+
+func TestTranslateRequest_StopArray(t *testing.T) {
+	in := decodeOAIRequest(t, `{"model":"m","messages":[{"role":"user","content":"hi"}],"stop":["A","B"]}`)
+	out, err := translateRequest(in, 4096)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"A", "B"}, out.StopSequences)
+}
+
+func TestTranslateRequest_Tools(t *testing.T) {
+	in := decodeOAIRequest(t, `{
+		"model": "m",
+		"messages": [{"role":"user","content":"weather?"}],
+		"tools": [{
+			"type": "function",
+			"function": {
+				"name": "get_weather",
+				"description": "Get weather",
+				"parameters": {"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}
+			}
+		}],
+		"tool_choice": "required"
+	}`)
+
+	out, err := translateRequest(in, 4096)
+	require.NoError(t, err)
+
+	require.Len(t, out.Tools, 1)
+	assert.Equal(t, "get_weather", out.Tools[0].Name)
+	assert.Equal(t, "Get weather", out.Tools[0].Description)
+	assert.JSONEq(t, `{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}`,
+		string(out.Tools[0].InputSchema))
+
+	require.NotNil(t, out.ToolChoice)
+	assert.Equal(t, "any", out.ToolChoice.Type)
+}
+
+func TestTranslateRequest_ToolChoiceVariants(t *testing.T) {
+	cases := []struct {
+		name       string
+		toolChoice string
+		wantType   string
+		wantName   string
+		dropTools  bool
+	}{
+		{"auto", `"auto"`, "auto", "", false},
+		{"required", `"required"`, "any", "", false},
+		{"named", `{"type":"function","function":{"name":"foo"}}`, "tool", "foo", false},
+		{"none", `"none"`, "", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := `{"model":"m","messages":[{"role":"user","content":"x"}],` +
+				`"tools":[{"type":"function","function":{"name":"foo","parameters":{"type":"object"}}}],` +
+				`"tool_choice":` + tc.toolChoice + `}`
+			out, err := translateRequest(decodeOAIRequest(t, body), 4096)
+			require.NoError(t, err)
+			if tc.dropTools {
+				assert.Nil(t, out.Tools, "tools omitted for tool_choice=none")
+				assert.Nil(t, out.ToolChoice)
+				return
+			}
+			require.NotNil(t, out.ToolChoice)
+			assert.Equal(t, tc.wantType, out.ToolChoice.Type)
+			assert.Equal(t, tc.wantName, out.ToolChoice.Name)
+		})
+	}
+}
+
+func TestTranslateRequest_AssistantToolCallsAndToolResult(t *testing.T) {
+	in := decodeOAIRequest(t, `{
+		"model": "m",
+		"messages": [
+			{"role":"user","content":"weather in Paris?"},
+			{"role":"assistant","content":null,"tool_calls":[
+				{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"location\":\"Paris\"}"}}
+			]},
+			{"role":"tool","tool_call_id":"call_1","content":"18C"}
+		]
+	}`)
+
+	out, err := translateRequest(in, 4096)
+	require.NoError(t, err)
+	require.Len(t, out.Messages, 3)
+
+	// user
+	assert.Equal(t, "user", out.Messages[0].Role)
+
+	// assistant tool_use
+	assert.Equal(t, "assistant", out.Messages[1].Role)
+	require.Len(t, out.Messages[1].Content, 1)
+	tu := out.Messages[1].Content[0]
+	assert.Equal(t, "tool_use", tu.Type)
+	assert.Equal(t, "call_1", tu.ID)
+	assert.Equal(t, "get_weather", tu.Name)
+	assert.JSONEq(t, `{"location":"Paris"}`, string(tu.Input))
+
+	// tool result becomes a user message with tool_result block
+	assert.Equal(t, "user", out.Messages[2].Role)
+	require.Len(t, out.Messages[2].Content, 1)
+	tr := out.Messages[2].Content[0]
+	assert.Equal(t, "tool_result", tr.Type)
+	assert.Equal(t, "call_1", tr.ToolUseID)
+	assert.JSONEq(t, `"18C"`, string(tr.Content))
+}
+
+func TestTranslateRequest_MergesConsecutiveToolResults(t *testing.T) {
+	in := decodeOAIRequest(t, `{
+		"model":"m",
+		"messages":[
+			{"role":"tool","tool_call_id":"a","content":"1"},
+			{"role":"tool","tool_call_id":"b","content":"2"}
+		]
+	}`)
+	out, err := translateRequest(in, 4096)
+	require.NoError(t, err)
+	require.Len(t, out.Messages, 1, "adjacent tool results merge into one user message")
+	assert.Len(t, out.Messages[0].Content, 2)
+}
+
+func TestTranslateRequest_ImageParts(t *testing.T) {
+	in := decodeOAIRequest(t, `{
+		"model":"m",
+		"messages":[{"role":"user","content":[
+			{"type":"text","text":"describe"},
+			{"type":"image_url","image_url":{"url":"data:image/png;base64,AAAA"}},
+			{"type":"image_url","image_url":{"url":"https://example.com/x.png"}}
+		]}]
+	}`)
+	out, err := translateRequest(in, 4096)
+	require.NoError(t, err)
+	require.Len(t, out.Messages, 1)
+	blocks := out.Messages[0].Content
+	require.Len(t, blocks, 3)
+
+	assert.Equal(t, "text", blocks[0].Type)
+
+	require.NotNil(t, blocks[1].Source)
+	assert.Equal(t, "base64", blocks[1].Source.Type)
+	assert.Equal(t, "image/png", blocks[1].Source.MediaType)
+	assert.Equal(t, "AAAA", blocks[1].Source.Data)
+
+	require.NotNil(t, blocks[2].Source)
+	assert.Equal(t, "url", blocks[2].Source.Type)
+	assert.Equal(t, "https://example.com/x.png", blocks[2].Source.URL)
+}
+
+func TestTranslateRequest_EmptyToolArgsDefaultsToObject(t *testing.T) {
+	in := decodeOAIRequest(t, `{
+		"model":"m",
+		"messages":[{"role":"assistant","content":null,"tool_calls":[
+			{"id":"c","type":"function","function":{"name":"f","arguments":""}}
+		]}]
+	}`)
+	out, err := translateRequest(in, 4096)
+	require.NoError(t, err)
+	require.Len(t, out.Messages, 1)
+	assert.JSONEq(t, `{}`, string(out.Messages[0].Content[0].Input))
+}
+
+func TestParseDataURI(t *testing.T) {
+	mt, data, ok := parseDataURI("data:image/jpeg;base64,Zm9v")
+	require.True(t, ok)
+	assert.Equal(t, "image/jpeg", mt)
+	assert.Equal(t, "Zm9v", data)
+
+	_, _, ok = parseDataURI("data:image/png,notbase64")
+	assert.False(t, ok, "non-base64 data URIs are not decoded")
+}

--- a/anth2oai/translate_response.go
+++ b/anth2oai/translate_response.go
@@ -1,0 +1,81 @@
+package anth2oai
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// chatCmplPrefix mirrors OpenAI's completion id convention.
+const chatCmplPrefix = "chatcmpl-"
+
+// translateResponse converts a non-streaming Anthropic Message into an OpenAI
+// ChatCompletion. It is pure; created is injected by the caller.
+func translateResponse(in *anthResponse, created int64) *oaiResponse {
+	var text strings.Builder
+	var toolCalls []oaiToolCall
+	for _, block := range in.Content {
+		switch block.Type {
+		case "text":
+			text.WriteString(block.Text)
+		case "tool_use":
+			toolCalls = append(toolCalls, oaiToolCall{
+				ID:   block.ID,
+				Type: "function",
+				Function: oaiFunctionCall{
+					Name:      block.Name,
+					Arguments: inputToArguments(block.Input),
+				},
+			})
+		}
+	}
+
+	msg := oaiRespMessage{Role: "assistant", ToolCalls: toolCalls}
+	// OpenAI represents "assistant made only tool calls" as content: null.
+	if !(text.Len() == 0 && len(toolCalls) > 0) {
+		s := text.String()
+		msg.Content = &s
+	}
+
+	return &oaiResponse{
+		ID:      chatCmplPrefix + in.ID,
+		Object:  "chat.completion",
+		Created: created,
+		Model:   in.Model,
+		Choices: []oaiChoice{{
+			Index:        0,
+			Message:      msg,
+			FinishReason: mapStopReason(in.StopReason),
+		}},
+		Usage: oaiUsage{
+			PromptTokens:     in.Usage.InputTokens,
+			CompletionTokens: in.Usage.OutputTokens,
+			TotalTokens:      in.Usage.InputTokens + in.Usage.OutputTokens,
+		},
+	}
+}
+
+// inputToArguments renders an Anthropic tool_use input as an OpenAI arguments
+// JSON string, defaulting to "{}".
+func inputToArguments(input json.RawMessage) string {
+	s := strings.TrimSpace(string(input))
+	if s == "" || s == "null" {
+		return "{}"
+	}
+	return s
+}
+
+// mapStopReason maps an Anthropic stop_reason to an OpenAI finish_reason.
+func mapStopReason(reason string) string {
+	switch reason {
+	case "end_turn", "stop_sequence":
+		return "stop"
+	case "max_tokens":
+		return "length"
+	case "tool_use":
+		return "tool_calls"
+	case "":
+		return ""
+	default:
+		return "stop"
+	}
+}

--- a/anth2oai/translate_response_test.go
+++ b/anth2oai/translate_response_test.go
@@ -1,0 +1,113 @@
+package anth2oai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTranslateResponse_Text(t *testing.T) {
+	in := &anthResponse{
+		ID:         "msg_123",
+		Model:      "glm-4.5-air",
+		Role:       "assistant",
+		Content:    []anthRespBlock{{Type: "text", Text: "OK"}},
+		StopReason: "end_turn",
+		Usage:      anthUsage{InputTokens: 10, OutputTokens: 2},
+	}
+	out := translateResponse(in, 1700000000)
+
+	assert.Equal(t, "chatcmpl-msg_123", out.ID)
+	assert.Equal(t, "chat.completion", out.Object)
+	assert.Equal(t, int64(1700000000), out.Created)
+	assert.Equal(t, "glm-4.5-air", out.Model)
+
+	require.Len(t, out.Choices, 1)
+	c := out.Choices[0]
+	assert.Equal(t, 0, c.Index)
+	assert.Equal(t, "assistant", c.Message.Role)
+	require.NotNil(t, c.Message.Content)
+	assert.Equal(t, "OK", *c.Message.Content)
+	assert.Equal(t, "stop", c.FinishReason)
+
+	assert.Equal(t, int64(10), out.Usage.PromptTokens)
+	assert.Equal(t, int64(2), out.Usage.CompletionTokens)
+	assert.Equal(t, int64(12), out.Usage.TotalTokens)
+}
+
+func TestTranslateResponse_ToolUse(t *testing.T) {
+	in := &anthResponse{
+		ID:    "msg_9",
+		Model: "m",
+		Content: []anthRespBlock{
+			{Type: "tool_use", ID: "toolu_1", Name: "get_weather", Input: json.RawMessage(`{"location":"Paris"}`)},
+		},
+		StopReason: "tool_use",
+		Usage:      anthUsage{InputTokens: 5, OutputTokens: 7},
+	}
+	out := translateResponse(in, 1)
+
+	c := out.Choices[0]
+	assert.Nil(t, c.Message.Content, "content is null when only tool calls are present")
+	require.Len(t, c.Message.ToolCalls, 1)
+	tc := c.Message.ToolCalls[0]
+	assert.Equal(t, "toolu_1", tc.ID)
+	assert.Equal(t, "function", tc.Type)
+	assert.Equal(t, "get_weather", tc.Function.Name)
+	assert.JSONEq(t, `{"location":"Paris"}`, tc.Function.Arguments)
+	assert.Equal(t, "tool_calls", c.FinishReason)
+}
+
+func TestTranslateResponse_TextAndToolUse(t *testing.T) {
+	in := &anthResponse{
+		ID:    "msg_x",
+		Model: "m",
+		Content: []anthRespBlock{
+			{Type: "text", Text: "Let me check. "},
+			{Type: "tool_use", ID: "t1", Name: "f", Input: json.RawMessage(`{}`)},
+		},
+		StopReason: "tool_use",
+	}
+	out := translateResponse(in, 1)
+	c := out.Choices[0]
+	require.NotNil(t, c.Message.Content)
+	assert.Equal(t, "Let me check. ", *c.Message.Content)
+	require.Len(t, c.Message.ToolCalls, 1)
+}
+
+func TestTranslateResponse_EmptyToolInput(t *testing.T) {
+	in := &anthResponse{
+		ID:      "m",
+		Content: []anthRespBlock{{Type: "tool_use", ID: "t", Name: "f"}},
+	}
+	out := translateResponse(in, 1)
+	assert.Equal(t, "{}", out.Choices[0].Message.ToolCalls[0].Function.Arguments)
+}
+
+func TestMapStopReason(t *testing.T) {
+	cases := map[string]string{
+		"end_turn":      "stop",
+		"stop_sequence": "stop",
+		"max_tokens":    "length",
+		"tool_use":      "tool_calls",
+		"":              "",
+		"weird":         "stop",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, mapStopReason(in), "stop_reason=%q", in)
+	}
+}
+
+// TestTranslateResponse_Marshals confirms the emitted JSON has the OpenAI shape
+// that an OpenAI SDK client deserialises.
+func TestTranslateResponse_Marshals(t *testing.T) {
+	in := &anthResponse{ID: "msg_1", Model: "m", Content: []anthRespBlock{{Type: "text", Text: "hi"}}, StopReason: "end_turn"}
+	out := translateResponse(in, 42)
+	b, err := json.Marshal(out)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"object":"chat.completion"`)
+	assert.Contains(t, string(b), `"finish_reason":"stop"`)
+	assert.Contains(t, string(b), `"role":"assistant"`)
+}

--- a/anth2oai/translate_stream.go
+++ b/anth2oai/translate_stream.go
@@ -19,8 +19,9 @@ type streamTransformer struct {
 	outputTokens int64
 
 	roleSent      bool
-	toolCallCount int         // number of tool_use blocks started so far
-	blockToolIdx  map[int]int // Anthropic block index -> OpenAI tool_call index
+	toolCallCount int          // number of tool_use blocks started so far
+	blockToolIdx  map[int]int  // Anthropic block index -> OpenAI tool_call index
+	toolArgsSeen  map[int]bool // Anthropic block index -> received any input_json_delta
 }
 
 func newStreamTransformer(created int64, includeUsage bool) *streamTransformer {
@@ -28,6 +29,7 @@ func newStreamTransformer(created int64, includeUsage bool) *streamTransformer {
 		created:      created,
 		includeUsage: includeUsage,
 		blockToolIdx: map[int]int{},
+		toolArgsSeen: map[int]bool{},
 	}
 }
 
@@ -79,9 +81,24 @@ func (s *streamTransformer) handle(ev *anthStreamEvent) (frames [][]byte, done b
 			if !ok {
 				return nil, false, nil
 			}
+			s.toolArgsSeen[ev.Index] = true
 			delta := oaiDelta{ToolCalls: []oaiToolCall{{
 				Index:    &idx,
 				Function: oaiFunctionCall{Arguments: ev.Delta.PartialJSON},
+			}}}
+			return s.frame(delta, nil), false, nil
+		}
+		return nil, false, nil
+
+	case "content_block_stop":
+		// A tool_use block that produced no input_json_delta would otherwise
+		// leave arguments as "" — emit "{}" so strict clients can json.Unmarshal,
+		// matching the non-streaming path's inputToArguments default.
+		if idx, ok := s.blockToolIdx[ev.Index]; ok && !s.toolArgsSeen[ev.Index] {
+			args := "{}"
+			delta := oaiDelta{ToolCalls: []oaiToolCall{{
+				Index:    &idx,
+				Function: oaiFunctionCall{Arguments: args},
 			}}}
 			return s.frame(delta, nil), false, nil
 		}
@@ -113,7 +130,7 @@ func (s *streamTransformer) handle(ev *anthStreamEvent) (frames [][]byte, done b
 		// The [DONE] terminator is written by the transport's finishStream on error.
 		return nil, true, fmt.Errorf("anth2oai: %s", msg)
 
-	case "ping", "content_block_stop":
+	case "ping":
 		return nil, false, nil
 
 	default:

--- a/anth2oai/translate_stream.go
+++ b/anth2oai/translate_stream.go
@@ -1,0 +1,168 @@
+package anth2oai
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// streamTransformer is the state machine that turns a stream of Anthropic SSE
+// events into OpenAI chat.completion.chunk SSE frames. It is keyed by
+// content-block index so interleaved text and tool_use blocks are tracked
+// independently, and it is incremental — one call per Anthropic event.
+type streamTransformer struct {
+	id           string
+	model        string
+	created      int64
+	includeUsage bool
+
+	inputTokens  int64
+	outputTokens int64
+
+	roleSent      bool
+	toolCallCount int         // number of tool_use blocks started so far
+	blockToolIdx  map[int]int // Anthropic block index -> OpenAI tool_call index
+}
+
+func newStreamTransformer(created int64, includeUsage bool) *streamTransformer {
+	return &streamTransformer{
+		created:      created,
+		includeUsage: includeUsage,
+		blockToolIdx: map[int]int{},
+	}
+}
+
+// handle consumes one Anthropic event and returns the SSE frames to write
+// (each already terminated with "\n\n", the [DONE] sentinel included when the
+// stream ends). done reports whether the stream is complete.
+func (s *streamTransformer) handle(ev *anthStreamEvent) (frames [][]byte, done bool, err error) {
+	switch ev.Type {
+	case "message_start":
+		if ev.Message != nil {
+			s.id = chatCmplPrefix + ev.Message.ID
+			s.model = ev.Message.Model
+			s.inputTokens = ev.Message.Usage.InputTokens
+		}
+		s.roleSent = true
+		role := "assistant"
+		empty := ""
+		return s.frame(oaiDelta{Role: role, Content: &empty}, nil), false, nil
+
+	case "content_block_start":
+		if ev.ContentBlock != nil && ev.ContentBlock.Type == "tool_use" {
+			idx := s.toolCallCount
+			s.toolCallCount++
+			s.blockToolIdx[ev.Index] = idx
+			args := ""
+			delta := oaiDelta{ToolCalls: []oaiToolCall{{
+				Index: &idx,
+				ID:    ev.ContentBlock.ID,
+				Type:  "function",
+				Function: oaiFunctionCall{
+					Name:      ev.ContentBlock.Name,
+					Arguments: args,
+				},
+			}}}
+			return s.frame(delta, nil), false, nil
+		}
+		return nil, false, nil
+
+	case "content_block_delta":
+		if ev.Delta == nil {
+			return nil, false, nil
+		}
+		switch ev.Delta.Type {
+		case "text_delta":
+			text := ev.Delta.Text
+			return s.frame(oaiDelta{Content: &text}, nil), false, nil
+		case "input_json_delta":
+			idx, ok := s.blockToolIdx[ev.Index]
+			if !ok {
+				return nil, false, nil
+			}
+			delta := oaiDelta{ToolCalls: []oaiToolCall{{
+				Index:    &idx,
+				Function: oaiFunctionCall{Arguments: ev.Delta.PartialJSON},
+			}}}
+			return s.frame(delta, nil), false, nil
+		}
+		return nil, false, nil
+
+	case "message_delta":
+		if ev.Usage != nil {
+			s.outputTokens = ev.Usage.OutputTokens
+		}
+		if ev.Delta != nil && ev.Delta.StopReason != "" {
+			fr := mapStopReason(ev.Delta.StopReason)
+			return s.frame(oaiDelta{}, &fr), false, nil
+		}
+		return nil, false, nil
+
+	case "message_stop":
+		var out [][]byte
+		if s.includeUsage {
+			out = append(out, s.usageFrame())
+		}
+		out = append(out, []byte("data: [DONE]\n\n"))
+		return out, true, nil
+
+	case "error":
+		msg := "upstream stream error"
+		if ev.Error != nil && ev.Error.Message != "" {
+			msg = ev.Error.Message
+		}
+		// The [DONE] terminator is written by the transport's finishStream on error.
+		return nil, true, fmt.Errorf("anth2oai: %s", msg)
+
+	case "ping", "content_block_stop":
+		return nil, false, nil
+
+	default:
+		return nil, false, nil
+	}
+}
+
+// frame marshals a single chunk into an SSE data frame.
+func (s *streamTransformer) frame(delta oaiDelta, finish *string) [][]byte {
+	chunk := oaiChunk{
+		ID:      s.id,
+		Object:  "chat.completion.chunk",
+		Created: s.created,
+		Model:   s.model,
+		Choices: []oaiChunkChoice{{
+			Index:        0,
+			Delta:        delta,
+			FinishReason: finish,
+		}},
+	}
+	return [][]byte{encodeSSE(chunk)}
+}
+
+// usageFrame emits a final usage-only chunk (choices: []) before [DONE].
+func (s *streamTransformer) usageFrame() []byte {
+	chunk := oaiChunk{
+		ID:      s.id,
+		Object:  "chat.completion.chunk",
+		Created: s.created,
+		Model:   s.model,
+		Choices: []oaiChunkChoice{},
+		Usage: &oaiUsage{
+			PromptTokens:     s.inputTokens,
+			CompletionTokens: s.outputTokens,
+			TotalTokens:      s.inputTokens + s.outputTokens,
+		},
+	}
+	return encodeSSE(chunk)
+}
+
+func encodeSSE(chunk oaiChunk) []byte {
+	b, err := json.Marshal(chunk)
+	if err != nil {
+		// oaiChunk is composed of JSON-safe types; marshal cannot realistically fail.
+		return []byte("data: {}\n\n")
+	}
+	out := make([]byte, 0, len(b)+8)
+	out = append(out, "data: "...)
+	out = append(out, b...)
+	out = append(out, '\n', '\n')
+	return out
+}

--- a/anth2oai/translate_stream_test.go
+++ b/anth2oai/translate_stream_test.go
@@ -149,6 +149,34 @@ func TestStream_IncludeUsage(t *testing.T) {
 	assert.Equal(t, int64(17), last.Usage.TotalTokens)
 }
 
+func TestStream_ToolNoArgsFlushesEmptyObject(t *testing.T) {
+	// A tool_use block with no input_json_delta must still yield valid JSON args.
+	events := []*anthStreamEvent{
+		{Type: "message_start", Message: &anthResponse{ID: "m", Model: "x"}},
+		{Type: "content_block_start", Index: 0, ContentBlock: &anthRespBlock{Type: "tool_use", ID: "t1", Name: "ping"}},
+		{Type: "content_block_stop", Index: 0},
+		{Type: "message_delta", Delta: &anthEventDelta{StopReason: "tool_use"}},
+		{Type: "message_stop"},
+	}
+	chunks, done := runTransformer(t, events, false)
+	require.True(t, done)
+
+	var name, args string
+	for _, c := range chunks {
+		if len(c.Choices) == 0 {
+			continue
+		}
+		for _, tc := range c.Choices[0].Delta.ToolCalls {
+			if tc.Function.Name != "" {
+				name = tc.Function.Name
+			}
+			args += tc.Function.Arguments
+		}
+	}
+	assert.Equal(t, "ping", name)
+	assert.JSONEq(t, `{}`, args, "empty tool args must serialize to valid JSON")
+}
+
 func TestStream_ErrorEvent(t *testing.T) {
 	tr := newStreamTransformer(1, false)
 	ev := &anthStreamEvent{Type: "error", Error: &anthErrorBody{Type: "overloaded_error", Message: "boom"}}

--- a/anth2oai/translate_stream_test.go
+++ b/anth2oai/translate_stream_test.go
@@ -1,0 +1,159 @@
+package anth2oai
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// parseAnthropicSSE extracts the JSON payloads of an Anthropic SSE stream.
+func parseAnthropicSSE(t *testing.T, raw string) []*anthStreamEvent {
+	t.Helper()
+	var events []*anthStreamEvent
+	sc := bufio.NewScanner(strings.NewReader(raw))
+	var data strings.Builder
+	flush := func() {
+		if data.Len() == 0 {
+			return
+		}
+		var ev anthStreamEvent
+		require.NoError(t, json.Unmarshal([]byte(data.String()), &ev))
+		events = append(events, &ev)
+		data.Reset()
+	}
+	for sc.Scan() {
+		line := sc.Text()
+		if line == "" {
+			flush()
+			continue
+		}
+		if strings.HasPrefix(line, "data:") {
+			data.WriteString(strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " "))
+		}
+	}
+	flush()
+	return events
+}
+
+// runTransformer feeds parsed events through the state machine and returns the
+// decoded OpenAI chunks plus whether [DONE] was seen.
+func runTransformer(t *testing.T, events []*anthStreamEvent, includeUsage bool) (chunks []oaiChunk, sawDone bool) {
+	t.Helper()
+	tr := newStreamTransformer(999, includeUsage)
+	for _, ev := range events {
+		frames, done, err := tr.handle(ev)
+		require.NoError(t, err)
+		for _, f := range frames {
+			s := string(f)
+			require.True(t, strings.HasPrefix(s, "data: "), "frame must start with 'data: ': %q", s)
+			payload := strings.TrimSuffix(strings.TrimPrefix(s, "data: "), "\n\n")
+			if payload == "[DONE]" {
+				sawDone = true
+				continue
+			}
+			var ch oaiChunk
+			require.NoError(t, json.Unmarshal([]byte(payload), &ch))
+			chunks = append(chunks, ch)
+		}
+		if done {
+			break
+		}
+	}
+	return chunks, sawDone
+}
+
+func TestStream_Text(t *testing.T) {
+	raw, err := os.ReadFile("testdata/text_stream.sse")
+	require.NoError(t, err)
+
+	events := parseAnthropicSSE(t, string(raw))
+	chunks, done := runTransformer(t, events, false)
+
+	require.True(t, done, "stream terminated with [DONE]")
+	require.NotEmpty(t, chunks)
+
+	// First chunk carries the assistant role.
+	assert.Equal(t, "assistant", chunks[0].Choices[0].Delta.Role)
+	assert.Equal(t, "chat.completion.chunk", chunks[0].Object)
+	assert.Equal(t, "chatcmpl-msg_text_1", chunks[0].ID)
+	assert.Equal(t, "glm-4.5-air", chunks[0].Model)
+
+	// Content accumulates to "OK".
+	var content strings.Builder
+	var finish string
+	for _, c := range chunks {
+		require.Len(t, c.Choices, 1)
+		if c.Choices[0].Delta.Content != nil {
+			content.WriteString(*c.Choices[0].Delta.Content)
+		}
+		if c.Choices[0].FinishReason != nil {
+			finish = *c.Choices[0].FinishReason
+		}
+	}
+	assert.Equal(t, "OK", content.String())
+	assert.Equal(t, "stop", finish)
+}
+
+func TestStream_Tool(t *testing.T) {
+	raw, err := os.ReadFile("testdata/tool_stream.sse")
+	require.NoError(t, err)
+
+	events := parseAnthropicSSE(t, string(raw))
+	chunks, done := runTransformer(t, events, false)
+	require.True(t, done)
+
+	var name, args string
+	var finish string
+	var toolIndex = -1
+	for _, c := range chunks {
+		if len(c.Choices) == 0 {
+			continue
+		}
+		for _, tcd := range c.Choices[0].Delta.ToolCalls {
+			if tcd.Index != nil {
+				toolIndex = *tcd.Index
+			}
+			if tcd.Function.Name != "" {
+				name = tcd.Function.Name
+			}
+			args += tcd.Function.Arguments
+		}
+		if c.Choices[0].FinishReason != nil {
+			finish = *c.Choices[0].FinishReason
+		}
+	}
+	assert.Equal(t, 0, toolIndex)
+	assert.Equal(t, "get_weather", name)
+	assert.JSONEq(t, `{"location":"Paris"}`, args)
+	assert.Equal(t, "tool_calls", finish)
+}
+
+func TestStream_IncludeUsage(t *testing.T) {
+	raw, err := os.ReadFile("testdata/text_stream.sse")
+	require.NoError(t, err)
+	events := parseAnthropicSSE(t, string(raw))
+	chunks, done := runTransformer(t, events, true)
+	require.True(t, done)
+
+	// The final non-DONE chunk is usage-only: empty choices, populated usage.
+	last := chunks[len(chunks)-1]
+	assert.Empty(t, last.Choices)
+	require.NotNil(t, last.Usage)
+	assert.Equal(t, int64(12), last.Usage.PromptTokens)
+	assert.Equal(t, int64(5), last.Usage.CompletionTokens)
+	assert.Equal(t, int64(17), last.Usage.TotalTokens)
+}
+
+func TestStream_ErrorEvent(t *testing.T) {
+	tr := newStreamTransformer(1, false)
+	ev := &anthStreamEvent{Type: "error", Error: &anthErrorBody{Type: "overloaded_error", Message: "boom"}}
+	_, done, err := tr.handle(ev)
+	require.Error(t, err)
+	assert.True(t, done)
+	assert.Contains(t, err.Error(), "boom")
+}

--- a/anth2oai/transport.go
+++ b/anth2oai/transport.go
@@ -23,7 +23,12 @@ type roundTripper struct {
 // NewRoundTripper builds the L2 transport. Plug it into any *http.Client or the
 // OpenAI SDK via option.WithHTTPClient.
 func NewRoundTripper(baseURL, apiKey string, opts ...Option) http.RoundTripper {
-	cfg := newConfig(baseURL, apiKey, opts...)
+	return newRoundTripper(newConfig(baseURL, apiKey, opts...))
+}
+
+// newRoundTripper builds the transport from an already-resolved config, so
+// callers that already hold a config (e.g. NewHandler) don't rebuild it.
+func newRoundTripper(cfg *config) *roundTripper {
 	return &roundTripper{
 		cfg:  cfg,
 		next: cfg.nextTransport(),

--- a/anth2oai/transport.go
+++ b/anth2oai/transport.go
@@ -1,0 +1,254 @@
+package anth2oai
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// roundTripper is the L2 http.RoundTripper. It accepts OpenAI Chat Completions
+// requests, translates them to Anthropic Messages requests, calls the upstream,
+// and translates the response back — for both non-streaming and streaming.
+type roundTripper struct {
+	cfg  *config
+	next http.RoundTripper
+	now  func() int64
+}
+
+// NewRoundTripper builds the L2 transport. Plug it into any *http.Client or the
+// OpenAI SDK via option.WithHTTPClient.
+func NewRoundTripper(baseURL, apiKey string, opts ...Option) http.RoundTripper {
+	cfg := newConfig(baseURL, apiKey, opts...)
+	return &roundTripper{
+		cfg:  cfg,
+		next: cfg.nextTransport(),
+		now:  func() int64 { return time.Now().Unix() },
+	}
+}
+
+// RoundTrip implements http.RoundTripper.
+func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if !strings.HasSuffix(strings.TrimSuffix(req.URL.Path, "/"), "chat/completions") {
+		return errorResponse(req, http.StatusNotFound,
+			newErrorBody("anth2oai only proxies POST /v1/chat/completions", "not_found_error")), nil
+	}
+
+	var body []byte
+	if req.Body != nil {
+		b, err := io.ReadAll(req.Body)
+		_ = req.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("anth2oai: reading request body: %w", err)
+		}
+		body = b
+	}
+
+	var oaiReq oaiRequest
+	if err := json.Unmarshal(body, &oaiReq); err != nil {
+		return errorResponse(req, http.StatusBadRequest,
+			newErrorBody("invalid OpenAI request body: "+err.Error(), "invalid_request_error")), nil
+	}
+
+	anthReq, err := translateRequest(&oaiReq, rt.cfg.defaultMaxTokens)
+	if err != nil {
+		return errorResponse(req, http.StatusBadRequest,
+			newErrorBody(err.Error(), "invalid_request_error")), nil
+	}
+
+	anthBody, err := json.Marshal(anthReq)
+	if err != nil {
+		return nil, fmt.Errorf("anth2oai: marshaling upstream request: %w", err)
+	}
+
+	upstreamReq, err := rt.buildUpstreamRequest(req, anthBody, oaiReq.Stream)
+	if err != nil {
+		return nil, err
+	}
+
+	rt.cfg.logger.WithFields(map[string]interface{}{
+		"model":  anthReq.Model,
+		"stream": anthReq.Stream,
+		"url":    upstreamReq.URL.String(),
+	}).Debug("anth2oai: forwarding to Anthropic upstream")
+
+	resp, err := rt.next.RoundTrip(upstreamReq)
+	if err != nil {
+		return nil, fmt.Errorf("anth2oai: upstream request failed: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return rt.errorFromUpstream(req, resp), nil
+	}
+
+	if oaiReq.Stream {
+		return rt.streamResponse(req, resp, oaiReq.StreamOptions), nil
+	}
+	return rt.nonStreamResponse(req, resp)
+}
+
+// buildUpstreamRequest constructs the Anthropic /v1/messages request.
+func (rt *roundTripper) buildUpstreamRequest(orig *http.Request, body []byte, stream bool) (*http.Request, error) {
+	url := strings.TrimRight(rt.cfg.baseURL, "/") + "/v1/messages"
+	up, err := http.NewRequestWithContext(orig.Context(), http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("anth2oai: building upstream request: %w", err)
+	}
+	up.Header.Set("Content-Type", "application/json")
+	up.Header.Set("anthropic-version", rt.cfg.anthropicVersion)
+	if rt.cfg.authKind == AuthXAPIKey {
+		up.Header.Set("x-api-key", rt.cfg.apiKey)
+	} else {
+		up.Header.Set("Authorization", "Bearer "+rt.cfg.apiKey)
+	}
+	if stream {
+		up.Header.Set("Accept", "text/event-stream")
+	} else {
+		up.Header.Set("Accept", "application/json")
+	}
+	up.ContentLength = int64(len(body))
+	return up, nil
+}
+
+// errorFromUpstream reads an upstream error body and maps it to OpenAI shape.
+func (rt *roundTripper) errorFromUpstream(req *http.Request, resp *http.Response) *http.Response {
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return errorResponse(req, resp.StatusCode, mapAnthropicError(resp.StatusCode, body))
+}
+
+// nonStreamResponse parses the Anthropic Message and returns an OpenAI body.
+func (rt *roundTripper) nonStreamResponse(req *http.Request, resp *http.Response) (*http.Response, error) {
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return errorResponse(req, http.StatusBadGateway,
+			newErrorBody("reading upstream response: "+err.Error(), "api_error")), nil
+	}
+	var anthResp anthResponse
+	if err := json.Unmarshal(raw, &anthResp); err != nil {
+		return errorResponse(req, http.StatusBadGateway,
+			newErrorBody("malformed upstream response: "+err.Error(), "api_error")), nil
+	}
+	oaiResp := translateResponse(&anthResp, rt.now())
+	out, err := json.Marshal(oaiResp)
+	if err != nil {
+		return nil, fmt.Errorf("anth2oai: marshaling response: %w", err)
+	}
+	return jsonResponse(req, http.StatusOK, out), nil
+}
+
+// streamResponse returns a response whose body lazily transforms the upstream
+// Anthropic SSE into OpenAI chunk SSE via an io.Pipe + goroutine, preserving
+// first-token latency.
+func (rt *roundTripper) streamResponse(req *http.Request, resp *http.Response, so *oaiStreamOptions) *http.Response {
+	includeUsage := so != nil && so.IncludeUsage
+	pr, pw := io.Pipe()
+
+	go rt.pumpStream(resp, pw, includeUsage)
+
+	h := make(http.Header)
+	h.Set("Content-Type", "text/event-stream")
+	h.Set("Cache-Control", "no-cache")
+	h.Set("Connection", "keep-alive")
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     http.StatusText(http.StatusOK),
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     h,
+		Body:       pr,
+		Request:    req,
+	}
+}
+
+// pumpStream reads the Anthropic SSE, transforms each event, and writes OpenAI
+// SSE frames to pw. It always closes pw.
+func (rt *roundTripper) pumpStream(resp *http.Response, pw *io.PipeWriter, includeUsage bool) {
+	defer resp.Body.Close()
+
+	transformer := newStreamTransformer(rt.now(), includeUsage)
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+
+	var data strings.Builder
+	dispatch := func() error {
+		if data.Len() == 0 {
+			return nil
+		}
+		payload := data.String()
+		data.Reset()
+		var ev anthStreamEvent
+		if err := json.Unmarshal([]byte(payload), &ev); err != nil {
+			rt.cfg.logger.WithFields(map[string]interface{}{
+				"error": err.Error(),
+			}).Warn("anth2oai: skipping malformed upstream SSE event")
+			return nil
+		}
+		frames, done, herr := transformer.handle(&ev)
+		for _, f := range frames {
+			if _, werr := pw.Write(f); werr != nil {
+				return werr
+			}
+		}
+		if herr != nil {
+			return herr
+		}
+		if done {
+			return io.EOF
+		}
+		return nil
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			if err := dispatch(); err != nil {
+				rt.finishStream(pw, err)
+				return
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "data:") {
+			value := strings.TrimPrefix(line, "data:")
+			value = strings.TrimPrefix(value, " ")
+			if data.Len() > 0 {
+				data.WriteByte('\n')
+			}
+			data.WriteString(value)
+		}
+		// event:, id:, retry:, and comments (":") are ignored.
+	}
+
+	// Flush a trailing event with no terminating blank line.
+	if err := dispatch(); err != nil {
+		rt.finishStream(pw, err)
+		return
+	}
+	if err := scanner.Err(); err != nil {
+		rt.finishStream(pw, err)
+		return
+	}
+	rt.finishStream(pw, nil)
+}
+
+// finishStream closes the pipe. On a real transport error (not the io.EOF used
+// to signal a clean [DONE]) it makes sure the client sees a terminator.
+func (rt *roundTripper) finishStream(pw *io.PipeWriter, err error) {
+	switch {
+	case err == nil || err == io.EOF:
+		_ = pw.Close()
+	default:
+		rt.cfg.logger.WithFields(map[string]interface{}{
+			"error": err.Error(),
+		}).Error("anth2oai: streaming aborted")
+		// Best-effort terminator so an OpenAI SSE reader unblocks.
+		_, _ = pw.Write([]byte("data: [DONE]\n\n"))
+		_ = pw.Close()
+	}
+}

--- a/anth2oai/transport_test.go
+++ b/anth2oai/transport_test.go
@@ -1,0 +1,220 @@
+package anth2oai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubTransport returns canned upstream responses and captures the request it
+// received, so tests can assert path rewriting, headers, and body translation.
+type stubTransport struct {
+	lastReq  *http.Request
+	lastBody []byte
+	respond  func(req *http.Request, body []byte) (*http.Response, error)
+}
+
+func (s *stubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, _ := io.ReadAll(req.Body)
+	s.lastReq = req
+	s.lastBody = body
+	return s.respond(req, body)
+}
+
+func newResp(status int, contentType, body string) *http.Response {
+	h := make(http.Header)
+	h.Set("Content-Type", contentType)
+	return &http.Response{
+		StatusCode: status,
+		Header:     h,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestRoundTrip_NonStreaming(t *testing.T) {
+	stub := &stubTransport{
+		respond: func(_ *http.Request, _ []byte) (*http.Response, error) {
+			return newResp(200, "application/json", `{
+				"id":"msg_1","type":"message","role":"assistant","model":"glm-4.5-air",
+				"content":[{"type":"text","text":"OK"}],
+				"stop_reason":"end_turn","usage":{"input_tokens":3,"output_tokens":1}
+			}`), nil
+		},
+	}
+	rt := NewRoundTripper("https://api.z.ai/api/anthropic", "secret", WithBaseTransport(stub))
+
+	req := newOAIRequest(t, "https://api.z.ai/api/anthropic/chat/completions", `{
+		"model":"glm-4.5-air","messages":[{"role":"user","content":"hi"}]
+	}`)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+
+	// Path rewritten to /v1/messages, auth + version headers set.
+	assert.Equal(t, "/api/anthropic/v1/messages", stub.lastReq.URL.Path)
+	assert.Equal(t, "Bearer secret", stub.lastReq.Header.Get("Authorization"))
+	assert.Equal(t, "2023-06-01", stub.lastReq.Header.Get("anthropic-version"))
+
+	// Upstream body is Anthropic-shaped with a default max_tokens.
+	var anthBody map[string]any
+	require.NoError(t, json.Unmarshal(stub.lastBody, &anthBody))
+	assert.Equal(t, float64(4096), anthBody["max_tokens"])
+
+	// Response body is OpenAI-shaped.
+	var out oaiResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	assert.Equal(t, "chat.completion", out.Object)
+	require.NotNil(t, out.Choices[0].Message.Content)
+	assert.Equal(t, "OK", *out.Choices[0].Message.Content)
+}
+
+func TestRoundTrip_XAPIKeyAuth(t *testing.T) {
+	stub := &stubTransport{
+		respond: func(_ *http.Request, _ []byte) (*http.Response, error) {
+			return newResp(200, "application/json",
+				`{"id":"m","model":"m","content":[{"type":"text","text":"x"}],"stop_reason":"end_turn","usage":{}}`), nil
+		},
+	}
+	rt := NewRoundTripper("https://up.example/anthropic", "k", WithBaseTransport(stub), WithAuthHeader(AuthXAPIKey))
+	req := newOAIRequest(t, "https://up.example/anthropic/chat/completions",
+		`{"model":"m","messages":[{"role":"user","content":"hi"}]}`)
+	_, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, "k", stub.lastReq.Header.Get("x-api-key"))
+	assert.Empty(t, stub.lastReq.Header.Get("Authorization"))
+}
+
+func TestRoundTrip_UpstreamError(t *testing.T) {
+	stub := &stubTransport{
+		respond: func(_ *http.Request, _ []byte) (*http.Response, error) {
+			return newResp(429, "application/json",
+				`{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}`), nil
+		},
+	}
+	rt := NewRoundTripper("https://up.example", "k", WithBaseTransport(stub))
+	req := newOAIRequest(t, "https://up.example/chat/completions",
+		`{"model":"m","messages":[{"role":"user","content":"hi"}]}`)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, 429, resp.StatusCode)
+
+	var env oaiErrorEnvelope
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&env))
+	assert.Equal(t, "slow down", env.Error.Message)
+	assert.Equal(t, "rate_limit_error", env.Error.Type)
+}
+
+func TestRoundTrip_Streaming(t *testing.T) {
+	sse, err := os.ReadFile("testdata/text_stream.sse")
+	require.NoError(t, err)
+	stub := &stubTransport{
+		respond: func(_ *http.Request, _ []byte) (*http.Response, error) {
+			return newResp(200, "text/event-stream", string(sse)), nil
+		},
+	}
+	rt := NewRoundTripper("https://up.example", "k", WithBaseTransport(stub))
+	req := newOAIRequest(t, "https://up.example/chat/completions",
+		`{"model":"m","messages":[{"role":"user","content":"hi"}],"stream":true}`)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+	assert.Equal(t, "text/event-stream", stub.lastReq.Header.Get("Accept"))
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	out := string(body)
+	assert.Contains(t, out, `"role":"assistant"`)
+	assert.Contains(t, out, `"content":"O"`)
+	assert.Contains(t, out, `"content":"K"`)
+	assert.Contains(t, out, `"finish_reason":"stop"`)
+	assert.True(t, strings.HasSuffix(strings.TrimSpace(out), "data: [DONE]"))
+}
+
+func TestRoundTrip_UnsupportedPath(t *testing.T) {
+	rt := NewRoundTripper("https://up.example", "k", WithBaseTransport(&stubTransport{
+		respond: func(_ *http.Request, _ []byte) (*http.Response, error) { return nil, nil },
+	}))
+	req := newOAIRequest(t, "https://up.example/models", `{}`)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, 404, resp.StatusCode)
+}
+
+// TestNew_EndToEndWithSDK drives the real OpenAI SDK client against a stub
+// upstream, proving the returned *openai.Client deserialises our output.
+func TestNew_EndToEndWithSDK(t *testing.T) {
+	stub := &stubTransport{
+		respond: func(_ *http.Request, _ []byte) (*http.Response, error) {
+			return newResp(200, "application/json", `{
+				"id":"msg_e2e","type":"message","role":"assistant","model":"glm-4.5-air",
+				"content":[{"type":"text","text":"OK"}],
+				"stop_reason":"end_turn","usage":{"input_tokens":8,"output_tokens":2}
+			}`), nil
+		},
+	}
+	client := New("https://api.z.ai/api/anthropic", "secret", WithBaseTransport(stub))
+
+	resp, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
+		Model: openai.F("glm-4.5-air"),
+		Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage("Reply with exactly: OK"),
+		}),
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	assert.Equal(t, "OK", resp.Choices[0].Message.Content)
+	assert.Equal(t, int64(8), resp.Usage.PromptTokens)
+	assert.Equal(t, int64(10), resp.Usage.TotalTokens)
+}
+
+// TestNewStreaming_EndToEndWithSDK drives client.Chat.Completions.NewStreaming
+// against a stub upstream, proving the OpenAI SDK's SSE decoder parses our
+// emitted chunks and accumulates them correctly.
+func TestNewStreaming_EndToEndWithSDK(t *testing.T) {
+	sse, err := os.ReadFile("testdata/text_stream.sse")
+	require.NoError(t, err)
+	stub := &stubTransport{
+		respond: func(_ *http.Request, _ []byte) (*http.Response, error) {
+			return newResp(200, "text/event-stream", string(sse)), nil
+		},
+	}
+	client := New("https://up.example", "k", WithBaseTransport(stub))
+
+	stream := client.Chat.Completions.NewStreaming(context.Background(), openai.ChatCompletionNewParams{
+		Model:    openai.F("m"),
+		Messages: openai.F([]openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")}),
+	})
+	defer stream.Close()
+
+	var content, finish string
+	for stream.Next() {
+		chunk := stream.Current()
+		if len(chunk.Choices) == 0 {
+			continue
+		}
+		content += chunk.Choices[0].Delta.Content
+		if chunk.Choices[0].FinishReason != "" {
+			finish = string(chunk.Choices[0].FinishReason)
+		}
+	}
+	require.NoError(t, stream.Err())
+	assert.Equal(t, "OK", content)
+	assert.Equal(t, "stop", finish)
+}
+
+func newOAIRequest(t *testing.T, url, body string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewReader([]byte(body)))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}

--- a/anth2oai/wire.go
+++ b/anth2oai/wire.go
@@ -1,0 +1,248 @@
+package anth2oai
+
+import "encoding/json"
+
+// This file defines plain JSON wire structs for the OpenAI Chat Completions and
+// Anthropic Messages formats.
+//
+// Why not the SDK types? The openai-go / anthropic-sdk-go request ("params")
+// types wrap every field in a param.Field helper that marshals but does NOT
+// unmarshal — so an inbound OpenAI request body cannot be reliably decoded back
+// into openai.ChatCompletionNewParams. The translators therefore operate on the
+// wire JSON directly. The official SDK types remain the public boundary: New()
+// returns a *openai.Client, and the OpenAI-shaped bytes these structs emit are
+// exactly what that client (and any other OpenAI client) deserialises.
+
+// ---- OpenAI request (inbound) ----
+
+type oaiRequest struct {
+	Model               string            `json:"model"`
+	Messages            []oaiMessage      `json:"messages"`
+	MaxTokens           *int64            `json:"max_tokens,omitempty"`
+	MaxCompletionTokens *int64            `json:"max_completion_tokens,omitempty"`
+	Temperature         *float64          `json:"temperature,omitempty"`
+	TopP                *float64          `json:"top_p,omitempty"`
+	Stop                json.RawMessage   `json:"stop,omitempty"` // string or []string
+	Tools               []oaiTool         `json:"tools,omitempty"`
+	ToolChoice          json.RawMessage   `json:"tool_choice,omitempty"` // string or object
+	Stream              bool              `json:"stream,omitempty"`
+	StreamOptions       *oaiStreamOptions `json:"stream_options,omitempty"`
+	N                   *int              `json:"n,omitempty"`
+}
+
+type oaiStreamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
+}
+
+type oaiMessage struct {
+	Role       string          `json:"role"`
+	Content    json.RawMessage `json:"content,omitempty"` // string or []oaiContentPart (may be null)
+	ToolCalls  []oaiToolCall   `json:"tool_calls,omitempty"`
+	ToolCallID string          `json:"tool_call_id,omitempty"`
+	Name       string          `json:"name,omitempty"`
+}
+
+type oaiContentPart struct {
+	Type     string       `json:"type"`
+	Text     string       `json:"text,omitempty"`
+	ImageURL *oaiImageURL `json:"image_url,omitempty"`
+}
+
+type oaiImageURL struct {
+	URL    string `json:"url"`
+	Detail string `json:"detail,omitempty"`
+}
+
+type oaiTool struct {
+	Type     string          `json:"type"`
+	Function oaiToolFunction `json:"function"`
+}
+
+type oaiToolFunction struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+}
+
+// ---- OpenAI response (outbound) ----
+
+type oaiResponse struct {
+	ID      string      `json:"id"`
+	Object  string      `json:"object"`
+	Created int64       `json:"created"`
+	Model   string      `json:"model"`
+	Choices []oaiChoice `json:"choices"`
+	Usage   oaiUsage    `json:"usage"`
+}
+
+type oaiChoice struct {
+	Index        int            `json:"index"`
+	Message      oaiRespMessage `json:"message"`
+	FinishReason string         `json:"finish_reason"`
+}
+
+type oaiRespMessage struct {
+	Role      string        `json:"role"`
+	Content   *string       `json:"content"`
+	ToolCalls []oaiToolCall `json:"tool_calls,omitempty"`
+}
+
+type oaiToolCall struct {
+	Index    *int            `json:"index,omitempty"`
+	ID       string          `json:"id,omitempty"`
+	Type     string          `json:"type,omitempty"`
+	Function oaiFunctionCall `json:"function"`
+}
+
+type oaiFunctionCall struct {
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments"`
+}
+
+type oaiUsage struct {
+	PromptTokens     int64 `json:"prompt_tokens"`
+	CompletionTokens int64 `json:"completion_tokens"`
+	TotalTokens      int64 `json:"total_tokens"`
+}
+
+// ---- OpenAI streaming chunk (outbound) ----
+
+type oaiChunk struct {
+	ID      string           `json:"id"`
+	Object  string           `json:"object"`
+	Created int64            `json:"created"`
+	Model   string           `json:"model"`
+	Choices []oaiChunkChoice `json:"choices"`
+	Usage   *oaiUsage        `json:"usage,omitempty"`
+}
+
+type oaiChunkChoice struct {
+	Index        int      `json:"index"`
+	Delta        oaiDelta `json:"delta"`
+	FinishReason *string  `json:"finish_reason"`
+}
+
+type oaiDelta struct {
+	Role      string        `json:"role,omitempty"`
+	Content   *string       `json:"content,omitempty"`
+	ToolCalls []oaiToolCall `json:"tool_calls,omitempty"`
+}
+
+// ---- Anthropic request (outbound) ----
+
+type anthRequest struct {
+	Model         string          `json:"model"`
+	MaxTokens     int64           `json:"max_tokens"`
+	System        []anthTextBlock `json:"system,omitempty"`
+	Messages      []anthMessage   `json:"messages"`
+	Temperature   *float64        `json:"temperature,omitempty"`
+	TopP          *float64        `json:"top_p,omitempty"`
+	StopSequences []string        `json:"stop_sequences,omitempty"`
+	Tools         []anthTool      `json:"tools,omitempty"`
+	ToolChoice    *anthToolChoice `json:"tool_choice,omitempty"`
+	Stream        bool            `json:"stream,omitempty"`
+}
+
+type anthTextBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type anthMessage struct {
+	Role    string             `json:"role"`
+	Content []anthContentBlock `json:"content"`
+}
+
+// anthContentBlock is a union over the Anthropic block types we emit:
+// text, image, tool_use and tool_result. Unused fields are omitted.
+type anthContentBlock struct {
+	Type string `json:"type"`
+	// text
+	Text string `json:"text,omitempty"`
+	// image
+	Source *anthImageSource `json:"source,omitempty"`
+	// tool_use
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+	// tool_result
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Content   json.RawMessage `json:"content,omitempty"`
+	IsError   bool            `json:"is_error,omitempty"`
+}
+
+type anthImageSource struct {
+	Type      string `json:"type"` // "base64" | "url"
+	MediaType string `json:"media_type,omitempty"`
+	Data      string `json:"data,omitempty"`
+	URL       string `json:"url,omitempty"`
+}
+
+type anthTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+type anthToolChoice struct {
+	Type string `json:"type"` // "auto" | "any" | "tool"
+	Name string `json:"name,omitempty"`
+}
+
+// ---- Anthropic response (inbound, non-streaming) ----
+
+type anthResponse struct {
+	ID           string          `json:"id"`
+	Type         string          `json:"type"`
+	Role         string          `json:"role"`
+	Model        string          `json:"model"`
+	Content      []anthRespBlock `json:"content"`
+	StopReason   string          `json:"stop_reason"`
+	StopSequence *string         `json:"stop_sequence"`
+	Usage        anthUsage       `json:"usage"`
+}
+
+type anthRespBlock struct {
+	Type  string          `json:"type"`
+	Text  string          `json:"text,omitempty"`
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+}
+
+type anthUsage struct {
+	InputTokens  int64 `json:"input_tokens"`
+	OutputTokens int64 `json:"output_tokens"`
+}
+
+// ---- Anthropic streaming events (inbound) ----
+
+type anthStreamEvent struct {
+	Type         string          `json:"type"`
+	Message      *anthResponse   `json:"message,omitempty"`       // message_start
+	Index        int             `json:"index"`                   // content_block_*
+	ContentBlock *anthRespBlock  `json:"content_block,omitempty"` // content_block_start
+	Delta        *anthEventDelta `json:"delta,omitempty"`         // content_block_delta / message_delta
+	Usage        *anthUsage      `json:"usage,omitempty"`         // message_delta
+	Error        *anthErrorBody  `json:"error,omitempty"`         // error
+}
+
+type anthEventDelta struct {
+	Type         string  `json:"type,omitempty"`          // text_delta | input_json_delta
+	Text         string  `json:"text,omitempty"`          // text_delta
+	PartialJSON  string  `json:"partial_json,omitempty"`  // input_json_delta
+	StopReason   string  `json:"stop_reason,omitempty"`   // message_delta
+	StopSequence *string `json:"stop_sequence,omitempty"` // message_delta
+}
+
+// ---- Anthropic / OpenAI error shapes ----
+
+type anthErrorEnvelope struct {
+	Type  string         `json:"type"`
+	Error *anthErrorBody `json:"error"`
+}
+
+type anthErrorBody struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}

--- a/docs/anth2oai.md
+++ b/docs/anth2oai.md
@@ -1,0 +1,149 @@
+# anth2oai — an OpenAI-compatible façade over Anthropic endpoints
+
+`anth2oai` (subpackage `github.com/shaharia-lab/goai/anth2oai`) lets you talk to
+an **Anthropic-format** inference endpoint — the Anthropic Messages API,
+`POST /v1/messages` — using the **OpenAI Chat Completions** shape and SDK.
+
+Many providers ship an Anthropic-compatible endpoint so that Claude Code can use
+them (Claude Code speaks the Anthropic Messages API): Z.ai/GLM, Kimi, DeepSeek,
+and Claude itself. `anth2oai` turns any of them into an OpenAI-compatible target,
+so existing OpenAI tooling and code can reach them unchanged.
+
+It translates OpenAI requests → Anthropic requests on the way out, and Anthropic
+responses → OpenAI responses on the way back — for both **non-streaming** and
+**streaming** calls.
+
+## Install
+
+```go
+import "github.com/shaharia-lab/goai/anth2oai"
+```
+
+## Quick start
+
+```go
+client := anth2oai.New("https://api.z.ai/api/anthropic", token)
+
+resp, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+    Model: openai.F("glm-4.5-air"),
+    Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+        openai.UserMessage("Reply with exactly: OK"),
+    }),
+})
+fmt.Println(resp.Choices[0].Message.Content)
+```
+
+`New` returns a plain `*openai.Client`; use the normal OpenAI SDK surface,
+including `Chat.Completions.NewStreaming(...)`.
+
+## Architecture — four layers
+
+```
+L3  anth2oai.New(...)      → *openai.Client preloaded with the L2 transport
+L4  anth2oai.NewHandler()  → OpenAI-compatible POST /v1/chat/completions proxy
+L2  anth2oai.NewRoundTripper(...) → http.RoundTripper (plug into any http.Client)
+L1  pure translators       OpenAI ⇄ Anthropic (request, response, SSE stream)
+```
+
+- **L1** — pure, deterministic translators with no I/O.
+- **L2** — an `http.RoundTripper` that reads the OpenAI request, rewrites the URL
+  from `…/chat/completions` to `{baseURL}/v1/messages`, sets upstream auth and
+  `anthropic-version`, and translates the body and response. Streaming is lazy
+  (an `io.Pipe` + goroutine) so first-token latency is preserved.
+- **L3** — `New(...)`, a convenience `*openai.Client`.
+- **L4** — `NewHandler(...)`, an `http.Handler` so any OpenAI HTTP client (in any
+  language) can reach the upstream.
+
+## Public API
+
+```go
+// L3 convenience client.
+func New(baseURL, apiKey string, opts ...Option) *openai.Client
+
+// L2 transport — plug into any http.Client or the OpenAI SDK.
+func NewRoundTripper(baseURL, apiKey string, opts ...Option) http.RoundTripper
+
+// L4 proxy handler — OpenAI-compatible POST /v1/chat/completions → Anthropic.
+func NewHandler(baseURL, apiKey string, opts ...Option) http.Handler
+
+// Options.
+func WithDefaultMaxTokens(n int) Option        // default 4096
+func WithAnthropicVersion(v string) Option      // default "2023-06-01"
+func WithAuthHeader(kind AuthKind) Option        // AuthBearer (default) | AuthXAPIKey
+func WithHTTPClient(c *http.Client) Option        // underlying transport for upstream calls
+func WithLogger(l goai.Logger) Option             // null logger by default
+func WithBaseTransport(rt http.RoundTripper) Option // for testing / composition
+```
+
+## Auth & headers
+
+By default the caller's key is forwarded as `Authorization: Bearer <key>`
+(validated against GLM/Z.ai, which Claude Code reaches via
+`ANTHROPIC_AUTH_TOKEN` as a bearer token), plus an `anthropic-version:
+2023-06-01` header. For endpoints that require the native Anthropic scheme, use
+`WithAuthHeader(anth2oai.AuthXAPIKey)` to send `x-api-key: <key>` instead.
+
+## Field mapping
+
+### Request (OpenAI → Anthropic)
+
+| OpenAI | Anthropic | Notes |
+|---|---|---|
+| `model` | `model` | Passthrough, verbatim (no aliasing). |
+| `max_tokens` / `max_completion_tokens` | `max_tokens` | Anthropic requires it; defaults to `WithDefaultMaxTokens` (4096). |
+| `system` / `developer` messages | `system` | Concatenated, order-preserving. |
+| `user` messages | `user` message | Text → `text` block; `image_url` → `image` block (best-effort). |
+| `assistant` messages | `assistant` message | Text → `text`; `tool_calls` → `tool_use`. |
+| `tool` messages | `user` message | `tool_call_id` → `tool_use_id`, content → `tool_result`. |
+| `temperature` | `temperature` | **Clamped to [0,1]** (OpenAI allows 0–2). |
+| `top_p` | `top_p` | Passthrough. |
+| `stop` | `stop_sequences` | String or array normalised to `[]string`. |
+| `tools[].function` | `tools[]` | `parameters` → `input_schema`. |
+| `tool_choice` | `tool_choice` | `auto`→`auto`, `required`→`any`, `{name}`→`{type:tool,name}`, `none`→ tools omitted. |
+| `stream`, `stream_options.include_usage` | `stream` | `include_usage` emits a final usage-only chunk. |
+
+Images: a `data:` URI becomes a base64 image block; any other URL becomes a URL
+image block. Support varies by upstream.
+
+### Response (Anthropic → OpenAI)
+
+- `content` text blocks are concatenated into `choices[0].message.content`
+  (null when only tool calls are present).
+- `tool_use` blocks become `tool_calls` with JSON `arguments`.
+- `stop_reason` → `finish_reason`: `end_turn`/`stop_sequence`→`stop`,
+  `max_tokens`→`length`, `tool_use`→`tool_calls`.
+- `usage.input_tokens`/`output_tokens` → `prompt_tokens`/`completion_tokens`.
+
+### Streaming (Anthropic SSE → OpenAI chunk SSE)
+
+The Anthropic typed events (`message_start`, `content_block_start`,
+`content_block_delta`, `message_delta`, `message_stop`, …) are reconstructed
+into `chat.completion.chunk` frames, terminated by `data: [DONE]`.
+
+## Unsupported (ignored in v1)
+
+`n > 1` (treated as 1), `logit_bias`, `presence_penalty`, `frequency_penalty`,
+`seed`, `response_format`, `logprobs`. No model aliasing. Only Chat Completions
+is proxied — not `/v1/models`, embeddings, or other OpenAI endpoints.
+
+## Errors
+
+Upstream Anthropic errors are mapped to the OpenAI error shape
+(`{"error": {"message", "type", "code"}}`), preserving the HTTP status, so they
+surface through the OpenAI SDK as a normal `*openai.Error`.
+
+## Example
+
+See [`_examples/anth2oai_glm`](../_examples/anth2oai_glm) for a runnable
+non-streaming + streaming demo driven entirely by environment variables.
+
+## Live integration tests
+
+`anth2oai/integration_test.go` (build tag `integration`) exercises a real
+endpoint. It is skipped unless both env vars are set:
+
+```bash
+export ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic
+export ANTHROPIC_AUTH_TOKEN=<your token>
+go test -tags=integration ./anth2oai/...
+```


### PR DESCRIPTION
## Summary

Adds `anth2oai`, the first subpackage in `goai` (`github.com/shaharia-lab/goai/anth2oai`). It lets a caller talk to an **Anthropic-format** inference endpoint (Anthropic Messages API, `POST /v1/messages`) using the **OpenAI Chat Completions** shape and SDK — translating OpenAI⇄Anthropic in both directions, for non-streaming and streaming.

Motivation: providers like Z.ai/GLM, Kimi and DeepSeek ship an Anthropic-compatible endpoint (so Claude Code can use them). This exposes any of them through the OpenAI interface, as an importable library — not a standalone proxy binary.

## Design — four layers, one core

- **L1** pure translators — `translate_request.go`, `translate_response.go`, `translate_stream.go` (SSE state machine). No I/O.
- **L2** `http.RoundTripper` (`transport.go`) — rewrites `…/chat/completions` → `{baseURL}/v1/messages`, sets auth + `anthropic-version`, translates body/response. Streaming is lazy (`io.Pipe` + goroutine) to preserve first-token latency.
- **L3** `New(baseURL, apiKey, opts…) *openai.Client` (`anth2oai.go`) — drive it with the normal OpenAI SDK.
- **L4** `NewHandler(…) http.Handler` (`handler.go`) — OpenAI-compatible `POST /v1/chat/completions` proxy for non-Go clients.

### Note on types
The alpha SDK "params" types wrap fields in a helper that marshals but does **not** unmarshal, so an inbound OpenAI body can't be decoded back into `openai.ChatCompletionNewParams`. The translators therefore work on plain JSON wire structs (`wire.go`); the official SDK types remain the public boundary (`New` returns `*openai.Client`).

## Coverage of the spec
- Model passthrough (no aliasing), default `max_tokens` (4096, configurable), temperature clamp to [0,1], `top_p`, `stop` normalization.
- System/developer, user (text + best-effort image), assistant (`tool_calls`→`tool_use`), tool (`tool_result`) messages; consecutive tool results merged into one user message.
- Tools + `tool_choice` (`auto`/`required`/named/`none`).
- `stream` + `stream_options.include_usage` (final usage-only chunk).
- Bearer (default) / `x-api-key` auth via `WithAuthHeader`.
- Anthropic error → OpenAI error envelope, status preserved.

## Tests
- 32 offline unit tests: request/response/stream translation, tool mapping, stop-reason mapping, temperature clamp, default max-tokens, error mapping, options.
- Streaming state machine tested against sanitized SSE fixtures in `anth2oai/testdata/` (no secrets).
- L2 tested with a stub transport; **end-to-end tests drive the real OpenAI SDK** client (non-streaming + `NewStreaming`) against a stub upstream, proving our output deserializes.
- `integration_test.go` (build tag `integration`) hits a live GLM/Z.ai endpoint; `t.Skip` unless `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` are set. Never reads any settings file.

```
go test ./anth2oai/...            # ok, 78.7% coverage
gofmt -l anth2oai/ && go vet ./anth2oai/...   # clean
go test -tags=integration ./anth2oai/...      # live GLM (env-gated)
```

## Docs & example
- `docs/anth2oai.md` — user-facing docs mirroring the other subsystems.
- `_examples/anth2oai_glm/` — runnable non-streaming + streaming demo (env-driven).

No secrets committed; fixtures sanitized. The implementation PRD is intentionally **not** included in this PR.