### PR TITLE
chore: fix pre-existing gosec findings and enforce gosec (#75)

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -39,9 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    # Non-blocking for now: legacy code has pre-existing findings tracked in
-    # issue #75. This surfaces issues without failing the build.
-    continue-on-error: true
+    # Blocking: a gosec finding fails the build. Genuine false positives must be
+    # suppressed in-code with a justified `#nosec Gxxx -- reason`.
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,15 +71,12 @@ repos:
         types: [go]
         pass_filenames: false
 
-      # gosec runs on demand only (stages: [manual]) — it is not enforced on
-      # every commit yet because of pre-existing findings in legacy code, which
-      # are tracked in issue #75 for a follow-up fix. Run it explicitly with:
-      #   pre-commit run gosec --hook-stage manual --all-files
+      # gosec runs on every commit and is blocking. Genuine false positives must
+      # be suppressed in-code with a justified `#nosec Gxxx -- reason`.
       - id: gosec
-        name: gosec (manual security scan)
-        description: Static security analysis with gosec (report-only for now).
+        name: gosec (security scan)
+        description: Static security analysis with gosec.
         entry: bash -c 'go run github.com/securego/gosec/v2/cmd/gosec@v2.27.1 -quiet ./...'
         language: system
         types: [go]
         pass_filenames: false
-        stages: [manual]

--- a/_examples/simple_chat_with_streaming_tools.go
+++ b/_examples/simple_chat_with_streaming_tools.go
@@ -26,7 +26,9 @@ func main() {
 	}
 
 	toolsProvider := goai.NewToolsProvider()
-	toolsProvider.AddTools(tools)
+	if err := toolsProvider.AddTools(tools); err != nil {
+		panic(err)
+	}
 
 	// Configure LLM Request
 	llm := goai.NewLLMRequest(goai.NewRequestConfig(

--- a/_examples/simple_mcp_server.go
+++ b/_examples/simple_mcp_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/shaharia-lab/goai"
 )
 
@@ -31,7 +32,9 @@ func main() {
 			var input struct {
 				Name string `json:"name"`
 			}
-			json.Unmarshal(params.Arguments, &input)
+			if err := json.Unmarshal(params.Arguments, &input); err != nil {
+				return goai.CallToolResult{}, err
+			}
 			return goai.CallToolResult{
 				Content: []goai.ToolResultContent{{
 					Type: "text",
@@ -40,7 +43,9 @@ func main() {
 			}, nil
 		},
 	}
-	baseServer.AddTools(tool)
+	if err := baseServer.AddTools(tool); err != nil {
+		panic(err)
+	}
 
 	// Create and run SSE server
 	server := goai.NewSSEServer(baseServer)

--- a/chat_history_sqlite.go
+++ b/chat_history_sqlite.go
@@ -28,7 +28,7 @@ func NewSQLiteChatHistoryStorage(db *sql.DB, logger Logger) (*SQLiteChatHistoryS
 	}
 
 	if err := storage.initSchema(context.Background()); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, fmt.Errorf("failed to initialize database schema: %w", err)
 	}
 
@@ -191,7 +191,7 @@ func (s *SQLiteChatHistoryStorage) AddMessage(ctx context.Context, sessionID str
 	}
 
 	insertSQL := `
-	INSERT INTO messages (chat_uuid, role, text, generated_at, input_token, output_token, metadata) 
+	INSERT INTO messages (chat_uuid, role, text, generated_at, input_token, output_token, metadata)
 	VALUES (?, ?, ?, ?, ?, ?, ?)`
 
 	_, err = tx.ExecContext(
@@ -268,9 +268,9 @@ func (s *SQLiteChatHistoryStorage) GetChat(ctx context.Context, sessionID string
 	}
 
 	messagesSQL := `
-	SELECT role, text, generated_at, input_token, output_token, metadata 
-	FROM messages 
-	WHERE chat_uuid = ? 
+	SELECT role, text, generated_at, input_token, output_token, metadata
+	FROM messages
+	WHERE chat_uuid = ?
 	ORDER BY generated_at ASC`
 
 	rows, err := s.db.QueryContext(ctx, messagesSQL, sessionID)

--- a/llm_provider_anthropic_streaming.go
+++ b/llm_provider_anthropic_streaming.go
@@ -173,7 +173,9 @@ func (p *AnthropicLLMProvider) streamAndProcessMessage(
 
 	for stream.Next() {
 		event := stream.Current()
-		msg.Accumulate(event)
+		if err := msg.Accumulate(event); err != nil {
+			return nil, fmt.Errorf("error accumulating streaming message: %w", err)
+		}
 
 		// we will accumulate the text for processing
 		// but at the same time we can send the delta

--- a/llm_provider_aws_bedrock.go
+++ b/llm_provider_aws_bedrock.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -17,6 +18,19 @@ import (
 // NewBedrockClientWrapper creates a new wrapper for bedrockruntime.Client
 func NewBedrockClientWrapper(client *bedrockruntime.Client) BedrockClient {
 	return &BedrockClientWrapper{client: client}
+}
+
+// maxTokenToInt32 safely converts a configured max-token count to the int32
+// the Bedrock SDK expects, clamping to the valid [0, math.MaxInt32] range so
+// the conversion can never overflow (gosec G115).
+func maxTokenToInt32(maxToken int64) int32 {
+	if maxToken < 0 {
+		return 0
+	}
+	if maxToken > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	return int32(maxToken)
 }
 
 // BedrockLLMProvider implements the LLMProvider interface using AWS Bedrock's official Go SDK.
@@ -121,7 +135,7 @@ func (p *BedrockLLMProvider) GetResponse(ctx context.Context, messages []LLMMess
 
 	var finalResponseTextBuilder strings.Builder
 	inferenceCfg := &types.InferenceConfiguration{
-		MaxTokens: aws.Int32(int32(config.maxToken)),
+		MaxTokens: aws.Int32(maxTokenToInt32(config.maxToken)),
 	}
 
 	if config.temperature > 0 {

--- a/llm_provider_aws_bedrock_maxtoken_test.go
+++ b/llm_provider_aws_bedrock_maxtoken_test.go
@@ -1,0 +1,29 @@
+package goai
+
+import (
+	"math"
+	"testing"
+)
+
+func TestMaxTokenToInt32(t *testing.T) {
+	tests := []struct {
+		name     string
+		maxToken int64
+		want     int32
+	}{
+		{name: "zero", maxToken: 0, want: 0},
+		{name: "typical", maxToken: 1000, want: 1000},
+		{name: "negative clamps to zero", maxToken: -5, want: 0},
+		{name: "max int32 unchanged", maxToken: math.MaxInt32, want: math.MaxInt32},
+		{name: "overflow clamps to max int32", maxToken: math.MaxInt32 + 1, want: math.MaxInt32},
+		{name: "large overflow clamps to max int32", maxToken: math.MaxInt64, want: math.MaxInt32},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := maxTokenToInt32(tt.maxToken); got != tt.want {
+				t.Errorf("maxTokenToInt32(%d) = %d, want %d", tt.maxToken, got, tt.want)
+			}
+		})
+	}
+}

--- a/llm_provider_aws_bedrock_streaming.go
+++ b/llm_provider_aws_bedrock_streaming.go
@@ -150,7 +150,7 @@ func (p *BedrockLLMProvider) GetStreamingResponse(ctx context.Context, messages 
 			currentToolInputBuffer = nil
 
 			inferenceCfg := &types.InferenceConfiguration{
-				MaxTokens: aws.Int32(int32(config.maxToken)),
+				MaxTokens: aws.Int32(maxTokenToInt32(config.maxToken)),
 			}
 
 			if config.temperature > 0 {

--- a/mcp_client.go
+++ b/mcp_client.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"strings"
 	"sync"
 	"time"
@@ -805,7 +805,9 @@ func (c *Client) GetProtocolVersion() string {
 func calculateBackoff(initial time.Duration, retryCount int) time.Duration {
 	// Exponential backoff with jitter
 	backoff := float64(initial) * math.Pow(2, float64(retryCount-1))
-	// Add jitter (±20%)
+	// Add jitter (±20%). math/rand/v2 is used deliberately: this is
+	// non-cryptographic timing jitter for retry backoff, not a security context.
+	// #nosec G404 -- non-cryptographic jitter for retry backoff, not a security context
 	jitter := (rand.Float64()*0.4 - 0.2) * backoff
 	duration := time.Duration(backoff + jitter)
 

--- a/mcp_client_sse.go
+++ b/mcp_client_sse.go
@@ -264,7 +264,7 @@ func (t *SSETransport) establishConnection(ctx context.Context, config ClientCon
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		t.logger.WithFields(map[string]interface{}{
 			"status_code": resp.StatusCode,
 			"url":         config.SSE.URL,

--- a/mcp_server_sse.go
+++ b/mcp_server_sse.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -295,9 +296,14 @@ func (s *SSEServer) handleSSEConnection(ctx context.Context, w http.ResponseWrit
 		}).Info("Client connection closed")
 	}()
 
-	endpointURL := fmt.Sprintf("http://%s/message?clientID=%s", r.Host, clientID)
+	// clientID is a server-generated UUID and is query-escaped for defense in
+	// depth; the response is a non-HTML text/event-stream, so this is not an
+	// HTML/JS sink (gosec G705).
+	endpointURL := fmt.Sprintf("http://%s/message?clientID=%s", r.Host, url.QueryEscape(clientID))
 	endpointEvent := fmt.Sprintf("event: endpoint\ndata: %s\n\n", endpointURL)
-	if _, err = fmt.Fprint(w, endpointEvent); err != nil {
+	// #nosec G705 -- SSE (non-HTML) text/event-stream, not an HTML/JS sink; clientID is a server-generated, escaped UUID
+	_, err = fmt.Fprint(w, endpointEvent)
+	if err != nil {
 		s.logger.WithErr(err).Error("Error sending endpoint data")
 	}
 	flusher.Flush()
@@ -469,6 +475,8 @@ func (s *SSEServer) Run(ctx context.Context) error {
 		},
 		Addr:    s.address,        // Use the configured address.
 		Handler: corsHandler(mux), // Wrap the mux with the CORS handler.
+		// Bound the header-read phase to defend against Slowloris (gosec G112).
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	s.LogMessage(LogLevelInfo, "startup", fmt.Sprintf("Starting SSE server on %s", s.address))

--- a/vector_storage_postgres.go
+++ b/vector_storage_postgres.go
@@ -23,7 +23,7 @@ type PostgresProvider struct {
 // qualifiedTableName returns the fully-qualified table identifier
 // (schema.collection) with both parts escaped via pq.QuoteIdentifier. SQL
 // identifiers cannot be passed as bind parameters, so quoting them here is the
-// injection defense that justifies the // #nosec G201 markers on the query
+// injection defense that justifies the gosec G201 suppressions on the query
 // builders below.
 func (p *PostgresProvider) qualifiedTableName(collection string) string {
 	return pq.QuoteIdentifier(p.schema) + "." + pq.QuoteIdentifier(collection)

--- a/vector_storage_postgres.go
+++ b/vector_storage_postgres.go
@@ -20,6 +20,20 @@ type PostgresProvider struct {
 	schema    string
 }
 
+// qualifiedTableName returns the fully-qualified table identifier
+// (schema.collection) with both parts escaped via pq.QuoteIdentifier. SQL
+// identifiers cannot be passed as bind parameters, so quoting them here is the
+// injection defense that justifies the // #nosec G201 markers on the query
+// builders below.
+func (p *PostgresProvider) qualifiedTableName(collection string) string {
+	return pq.QuoteIdentifier(p.schema) + "." + pq.QuoteIdentifier(collection)
+}
+
+// quotedSchema returns the provider's schema name escaped as a SQL identifier.
+func (p *PostgresProvider) quotedSchema() string {
+	return pq.QuoteIdentifier(p.schema)
+}
+
 // PostgresStorageConfig holds configuration for PostgreSQL vector storage.
 type PostgresStorageConfig struct {
 	// ConnectionString is the PostgreSQL connection string
@@ -49,7 +63,7 @@ func NewPostgresProvider(config PostgresStorageConfig) (*PostgresProvider, error
 
 	// Test connection and check pgvector extension
 	if err := initializePostgres(db, config.SchemaName); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, err
 	}
 
@@ -72,7 +86,7 @@ func (p *PostgresProvider) Initialize(ctx context.Context) error {
 	}
 
 	// Create schema if not exists
-	if _, err := p.db.ExecContext(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", p.schema)); err != nil {
+	if _, err := p.db.ExecContext(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", p.quotedSchema())); err != nil {
 		return &VectorError{
 			Code:    ErrCodeOperationFailed,
 			Message: "failed to create schema",
@@ -91,7 +105,7 @@ func (p *PostgresProvider) Initialize(ctx context.Context) error {
 			custom_fields JSONB,
 			created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 		)
-	`, p.schema)
+	`, p.quotedSchema())
 
 	if _, err := p.db.ExecContext(ctx, query); err != nil {
 		return &VectorError{
@@ -122,7 +136,7 @@ func (p *PostgresProvider) CreateCollection(ctx context.Context, config *VectorC
 	defer tx.Rollback()
 
 	// Create collection table
-	tableName := fmt.Sprintf("%s.%s", p.schema, config.Name)
+	tableName := p.qualifiedTableName(config.Name)
 	if err := p.createCollectionTable(ctx, tx, tableName, config); err != nil {
 		return err
 	}
@@ -144,7 +158,7 @@ func (p *PostgresProvider) DeleteCollection(ctx context.Context, name string) er
 	defer tx.Rollback()
 
 	// Drop collection table
-	tableName := fmt.Sprintf("%s.%s", p.schema, name)
+	tableName := p.qualifiedTableName(name)
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)); err != nil {
 		return &VectorError{
 			Code:    ErrCodeOperationFailed,
@@ -164,8 +178,8 @@ func (p *PostgresProvider) DeleteCollection(ctx context.Context, name string) er
 // ListCollections implements VectorStorage.ListCollections.
 func (p *PostgresProvider) ListCollections(ctx context.Context) ([]string, error) {
 	query := `
-		SELECT name 
-		FROM vector_collections 
+		SELECT name
+		FROM vector_collections
 		WHERE schema_name = $1
 		ORDER BY name`
 
@@ -202,7 +216,8 @@ func (p *PostgresProvider) UpsertDocument(ctx context.Context, collection string
 		return err
 	}
 
-	tableName := fmt.Sprintf("%s.%s", p.schema, collection)
+	tableName := p.qualifiedTableName(collection)
+	// #nosec G201 -- table identifier is escaped via pq.QuoteIdentifier; all values use bind params
 	query := fmt.Sprintf(`
 		INSERT INTO %s (id, vector, content, metadata, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, $5, $6)
@@ -303,7 +318,8 @@ func (p *PostgresProvider) UpsertDocuments(ctx context.Context, collection strin
 
 // GetDocument implements VectorStorage.GetDocument.
 func (p *PostgresProvider) GetDocument(ctx context.Context, collection, id string) (*VectorDocument, error) {
-	tableName := fmt.Sprintf("%s.%s", p.schema, collection)
+	tableName := p.qualifiedTableName(collection)
+	// #nosec G201 -- table identifier is escaped via pq.QuoteIdentifier; all values use bind params
 	query := fmt.Sprintf(`
 		SELECT id, vector, content, metadata, created_at, updated_at
 		FROM %s
@@ -347,7 +363,8 @@ func (p *PostgresProvider) GetDocument(ctx context.Context, collection, id strin
 
 // DeleteDocument implements VectorStorage.DeleteDocument.
 func (p *PostgresProvider) DeleteDocument(ctx context.Context, collection, id string) error {
-	tableName := fmt.Sprintf("%s.%s", p.schema, collection)
+	tableName := p.qualifiedTableName(collection)
+	// #nosec G201 -- table identifier is escaped via pq.QuoteIdentifier; id uses a bind param
 	query := fmt.Sprintf("DELETE FROM %s WHERE id = $1", tableName)
 
 	result, err := p.db.ExecContext(ctx, query, id)
@@ -389,7 +406,7 @@ func (p *PostgresProvider) SearchByVector(ctx context.Context, collection string
 		}
 	}
 
-	tableName := fmt.Sprintf("%s.%s", p.schema, collection)
+	tableName := p.qualifiedTableName(collection)
 	query := p.buildSearchQuery(tableName, opts)
 
 	vec := pgvector.NewVector(vector)
@@ -431,7 +448,7 @@ func initializePostgres(db *sql.DB, schema string) error {
 	}
 
 	// Create schema if not exists
-	if _, err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", schema)); err != nil {
+	if _, err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pq.QuoteIdentifier(schema))); err != nil {
 		return &VectorError{
 			Code:    ErrCodeOperationFailed,
 			Message: "failed to create schema",
@@ -449,7 +466,7 @@ func initializePostgres(db *sql.DB, schema string) error {
 			distance_type TEXT NOT NULL,
 			custom_fields JSONB,
 			created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
-		)`, schema)
+		)`, pq.QuoteIdentifier(schema))
 
 	if _, err := db.Exec(query); err != nil {
 		return &VectorError{
@@ -506,11 +523,12 @@ func (p *PostgresProvider) storeCollectionMetadata(ctx context.Context, tx *sql.
 		}
 	}
 
+	// #nosec G201 -- schema identifier is escaped via pq.QuoteIdentifier; all values use bind params
 	query := fmt.Sprintf(`
-		INSERT INTO %s.vector_collections 
+		INSERT INTO %s.vector_collections
 		(name, schema_name, dimension, index_type, distance_type, custom_fields)
 		VALUES ($1, $2, $3, $4, $5, $6)
-	`, p.schema)
+	`, p.quotedSchema())
 
 	_, err = tx.ExecContext(ctx, query,
 		config.Name,
@@ -536,10 +554,11 @@ func (p *PostgresProvider) storeCollectionMetadata(ctx context.Context, tx *sql.
 }
 
 func (p *PostgresProvider) deleteCollectionMetadata(ctx context.Context, tx *sql.Tx, name string) error {
+	// #nosec G201 -- schema identifier is escaped via pq.QuoteIdentifier; all values use bind params
 	query := fmt.Sprintf(`
-		DELETE FROM %s.vector_collections 
+		DELETE FROM %s.vector_collections
 		WHERE name = $1 AND schema_name = $2
-	`, p.schema)
+	`, p.quotedSchema())
 
 	result, err := tx.ExecContext(ctx, query, name, p.schema)
 	if err != nil {
@@ -563,11 +582,12 @@ func (p *PostgresProvider) deleteCollectionMetadata(ctx context.Context, tx *sql
 }
 
 func (p *PostgresProvider) getCollectionConfig(ctx context.Context, name string) (*VectorCollectionConfig, error) {
+	// #nosec G201 -- schema identifier is escaped via pq.QuoteIdentifier; all values use bind params
 	query := fmt.Sprintf(`
 		SELECT dimension, index_type, distance_type, custom_fields
 		FROM %s.vector_collections
 		WHERE name = $1 AND schema_name = $2
-	`, p.schema)
+	`, p.quotedSchema())
 
 	var config VectorCollectionConfig
 	var customFields []byte
@@ -604,9 +624,9 @@ func (p *PostgresProvider) getCollectionConfig(ctx context.Context, name string)
 func (p *PostgresProvider) buildSearchQuery(tableName string, opts *VectorSearchOptions) string {
 	var query strings.Builder
 	query.WriteString(`
-		SELECT 
-			id, 
-			content, 
+		SELECT
+			id,
+			content,
 			metadata,
 			created_at,
 			updated_at,
@@ -660,7 +680,7 @@ func (p *PostgresProvider) buildIndexQuery(tableName string, config *VectorColle
 }
 
 func (p *PostgresProvider) prepareBulkInsertStmt(ctx context.Context, tx *sql.Tx, collection string) (*sql.Stmt, error) {
-	tableName := fmt.Sprintf("%s.%s", p.schema, collection)
+	tableName := p.qualifiedTableName(collection)
 	query := fmt.Sprintf(`
 		INSERT INTO %s (id, vector, content, metadata, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, $5, $6)

--- a/vector_storage_postgres_quoting_test.go
+++ b/vector_storage_postgres_quoting_test.go
@@ -1,0 +1,41 @@
+package goai
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestQualifiedTableNameQuoting verifies that schema/collection identifiers are
+// escaped via pq.QuoteIdentifier so a hostile collection name cannot break out
+// of the identifier position and inject SQL (the defense behind the G201
+// suppressions in this file).
+func TestQualifiedTableNameQuoting(t *testing.T) {
+	p := &PostgresProvider{schema: "public"}
+
+	got := p.qualifiedTableName("docs")
+	if want := `"public"."docs"`; got != want {
+		t.Errorf("qualifiedTableName(%q) = %q, want %q", "docs", got, want)
+	}
+
+	// A name attempting to inject a statement must be neutralised: the whole
+	// thing stays a single quoted identifier and any embedded double-quote is
+	// doubled (pq escaping), so no SQL metacharacter escapes the identifier.
+	hostile := `docs"; DROP TABLE users; --`
+	quoted := p.qualifiedTableName(hostile)
+	if want := `"public"."docs""; DROP TABLE users; --"`; quoted != want {
+		t.Fatalf("qualifiedTableName(hostile) = %q, want %q", quoted, want)
+	}
+	// The hostile input's embedded quote must be doubled (escaped), and the
+	// dangerous unescaped sequence `docs";` (which would terminate the
+	// identifier early) must NOT appear.
+	if strings.Contains(quoted, `docs";`) {
+		t.Errorf("embedded quote not escaped — identifier can be broken out of: %q", quoted)
+	}
+}
+
+func TestQuotedSchema(t *testing.T) {
+	p := &PostgresProvider{schema: "my_schema"}
+	if got, want := p.quotedSchema(), `"my_schema"`; got != want {
+		t.Errorf("quotedSchema() = %q, want %q", got, want)
+	}
+}

--- a/vector_storage_postgres_test.go
+++ b/vector_storage_postgres_test.go
@@ -36,12 +36,12 @@ func TestNewPostgresProvider(t *testing.T) {
 		mock.ExpectQuery(`SELECT EXISTS\(SELECT 1 FROM pg_extension WHERE extname = 'vector'\)`).
 			WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
 
-		// Then expect schema creation
-		mock.ExpectExec("CREATE SCHEMA IF NOT EXISTS public").
+		// Then expect schema creation (identifiers are pq.QuoteIdentifier-quoted)
+		mock.ExpectExec(`CREATE SCHEMA IF NOT EXISTS "public"`).
 			WillReturnResult(sqlmock.NewResult(0, 0))
 
 		// Finally expect metadata table creation
-		mock.ExpectExec("CREATE TABLE IF NOT EXISTS public.vector_collections").
+		mock.ExpectExec(`CREATE TABLE IF NOT EXISTS "public".vector_collections`).
 			WillReturnResult(sqlmock.NewResult(0, 0))
 
 		provider := &PostgresProvider{


### PR DESCRIPTION
Closes #75

Resolves all **18 pre-existing gosec findings** in legacy code and flips gosec to a **blocking** check in CI and pre-commit. `gosec ./...` now reports **0 issues**.

## WHAT
- Fix or justifiably suppress every gosec finding (3 HIGH, 8 MEDIUM, 7 LOW).
- Make gosec enforcing: drop `continue-on-error` in CI and `stages: [manual]` in pre-commit.

## HOW — real fixes (10)
| Rule | Fix |
|---|---|
| **G115** ×2 (`llm_provider_aws_bedrock*.go`) | New `maxTokenToInt32` helper clamps `maxToken` to `[0, MaxInt32]` before the `int32` conversion (+ unit test). |
| **G112** (`mcp_server_sse.go`) | Add `ReadHeaderTimeout: 10s` to the SSE `http.Server` (Slowloris). |
| **G104** ×7 | Handle/explicitly discard previously-ignored errors: `db.Close()`, `resp.Body.Close()`, `msg.Accumulate` (now propagated), example `AddTools`/`json.Unmarshal`. |
| **G201** ×6 (`vector_storage_postgres.go`) | Quote schema/collection SQL identifiers via `pq.QuoteIdentifier` (`qualifiedTableName`/`quotedSchema` helpers) — identifiers can't be bind params. Values still use `$n` binds; the raw schema **value** is correctly left unquoted where it's a bind param. |

## HOW — justified `#nosec` (8, each with a `-- reason`)
- **G404** — `math/rand/v2` jitter for retry backoff (non-cryptographic).
- **G705** — SSE `text/event-stream` (non-HTML sink); `clientID` is a server-generated, `url.QueryEscape`-escaped UUID.
- **G201** ×6 — identifiers escaped via `pq.QuoteIdentifier`; a `TestQualifiedTableNameQuoting` test proves a hostile collection name is neutralised.

## Enforcement
- **CI** (`.github/workflows/CI.yaml`): remove `continue-on-error`; run pinned `gosec@v2.27.1` via `go run` (same version as pre-commit, no drift).
- **pre-commit** (`.pre-commit-config.yaml`): remove `stages: [manual]`; update comments/name/description.

## Verification
- `gosec ./...` → **0 issues** (8 nosec-suppressed); pre-commit gosec hook passes on commit.
- `go build`, `go vet`, `gofmt` clean.
- `go test ./...` passes **except** the pre-existing flaky `TestSSEConnectionFlow` race (issue #40) — reproduces identically on `main`, unrelated to this change.

## Notes for reviewer
- **CI does not currently start** on this repo (`startup_failure` at 0s on `main` and prior PRs too — a pre-existing workflow-infra issue, out of scope for #75). The `gosec` job change is valid YAML/Actions syntax; it will enforce once CI is unblocked separately. The green check here is CodeQL.
