### PR TITLE
fix: idempotent SSE client teardown — stop 'close of closed channel' panic (#77)

### DIFF
--- a/mcp_server_sse.go
+++ b/mcp_server_sse.go
@@ -266,8 +266,7 @@ func (s *SSEServer) handleSSEConnection(ctx context.Context, w http.ResponseWrit
 		}).Info("SSE client disconnecting")
 
 		s.handleClientDisconnect(r.Context(), clientID)
-		delete(s.clients, clientID)
-		close(messageChan)
+		s.closeClientLocked(clientID)
 		s.clientsMutex.Unlock()
 
 		s.logger.WithFields(map[string]interface{}{
@@ -516,14 +515,24 @@ func (s *SSEServer) Run(ctx context.Context) error {
 	}
 }
 
-func (s *SSEServer) removeClient(clientID string) {
-	s.clientsMutex.Lock()
-	defer s.clientsMutex.Unlock()
-
+// closeClientLocked closes a client's message channel and removes it from the
+// registry, but only if it is still registered. The caller MUST hold
+// clientsMutex. It is idempotent: a second call for the same client is a no-op,
+// so the two teardown paths (the handleSSEConnection cleanup defer and
+// removeClient) can never double-close the channel — which previously caused a
+// "close of closed channel" panic under concurrent disconnects (#77).
+func (s *SSEServer) closeClientLocked(clientID string) {
 	if ch, exists := s.clients[clientID]; exists {
 		close(ch)
 		delete(s.clients, clientID)
 	}
+}
+
+func (s *SSEServer) removeClient(clientID string) {
+	s.clientsMutex.Lock()
+	defer s.clientsMutex.Unlock()
+
+	s.closeClientLocked(clientID)
 	s.activeConnections.Delete(clientID)
 }
 

--- a/mcp_server_sse_teardown_test.go
+++ b/mcp_server_sse_teardown_test.go
@@ -1,0 +1,50 @@
+package goai
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestCloseClientLockedIdempotent verifies that a client's channel is closed
+// exactly once even when the two teardown paths race. It reproduces the #77
+// scenario: many goroutines each call closeClientLocked (under the mutex) for
+// the same client. Before the fix this double-closed the channel and paniced
+// with "close of closed channel"; now the second and later calls are no-ops.
+func TestCloseClientLockedIdempotent(t *testing.T) {
+	s := &SSEServer{clients: make(map[string]chan []byte)}
+	clientID := "c1"
+	s.clients[clientID] = make(chan []byte, 1)
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			// Mirror the real teardown paths, which hold clientsMutex.
+			s.clientsMutex.Lock()
+			s.closeClientLocked(clientID)
+			s.clientsMutex.Unlock()
+		}()
+	}
+	wg.Wait() // a double-close would have paniced here
+
+	s.clientsMutex.RLock()
+	_, exists := s.clients[clientID]
+	s.clientsMutex.RUnlock()
+	if exists {
+		t.Fatal("client should have been removed from the registry after close")
+	}
+}
+
+// TestRemoveClientIdempotent ensures removeClient can be called repeatedly for
+// the same client (as the send-timeout and receive-loop paths may) without
+// panicking.
+func TestRemoveClientIdempotent(t *testing.T) {
+	s := &SSEServer{clients: make(map[string]chan []byte)}
+	s.clients["c1"] = make(chan []byte, 1)
+
+	s.removeClient("c1")
+	s.removeClient("c1") // second call must be a safe no-op
+	s.removeClient("never-registered")
+}


### PR DESCRIPTION
Closes #77

Fixes the intermittent `panic: close of closed channel` in `TestSSEConnectionFlow` and, more importantly, in the SSE server itself under concurrent client disconnects.

## WHAT
Make SSE client teardown close each client's `messageChan` **exactly once**.

## WHY
`handleSSEConnection`'s cleanup defer closed the client's `messageChan` **unconditionally**, while `removeClient` — called concurrently from the send-timeout path (`sendMessageToClient`) and the receive loop — also closed the same channel (guarded). When both teardown paths fired for one client, the channel was closed twice → `panic: close of closed channel`. Intermittent by nature, so it made `go test ./...` flaky (reproduced ~1 in 2–3 runs on clean `main`).

## HOW
- Extract the guarded close+delete into `closeClientLocked(clientID)` — caller holds `clientsMutex`; it closes+deletes only if the client is still registered, so it is **idempotent**.
- Route **both** teardown paths through it: the `handleSSEConnection` defer (which already holds the lock) and `removeClient`. A client channel is now closed by whichever path reaches it first; the other is a no-op.
- `activeConnections` cleanup is unchanged (defer → `handleClientDisconnect`; `removeClient` deletes directly).

## Tests
- `TestCloseClientLockedIdempotent` — 50 goroutines racing `closeClientLocked` for one client; a double-close would panic. Passes under `-race`.
- `TestRemoveClientIdempotent` — repeated `removeClient` calls are safe no-ops.
- Verified: `go test -run TestSSEConnectionFlow -count=20` no longer panics; full `go test ./...` (CI-equivalent, no `-race`) is green.

## Acceptance criteria
- [x] `go test ./... -count=20` — zero `close of closed channel` panics.
- [x] Each `messageChan` closed exactly once, under `clientsMutex`.
- [x] `-race` on the teardown path is clean (dedicated tests).
- [x] `TestSSEConnectionFlow` still asserts connect → message → disconnect.

## Deferred (out of scope, filed separately)
- **#79** — a *separate*, pre-existing data race in `TestSSEConnectionFlow` under `-race`: the test reads `httptest.ResponseRecorder` headers concurrently with the handler's header writes during connection **setup** (not teardown). Reproduces on clean `main`; CI's non-`-race` `go test` is unaffected.
