### PR TITLE
ci: pin all GitHub Actions to full commit SHAs to fix CI startup_failure (#78)

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -15,18 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: '^1.22'
           check-latest: true
           cache: true
 
       - name: Lint Code Base
-        uses: github/super-linter/slim@v4
+        uses: github/super-linter/slim@985ef206aaca4d560cb9ee2af2b42ba44adc1d55 # v4
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
@@ -44,10 +44,10 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run gosec
-        uses: securego/gosec@master
+        uses: securego/gosec@9e6a9843d7a4a6e3e9a8539b02612c8a4aa3f889 # v2.27.1
         with:
           args: ./...
 
@@ -55,10 +55,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: '^1.22'
           check-latest: true
@@ -68,10 +68,10 @@ jobs:
         run: go test -race ./... -covermode=atomic -coverprofile=coverage.out
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
 
       - name: Publish artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           retention-days: 1
           name: coverage.out
@@ -82,17 +82,17 @@ jobs:
     needs: test
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: coverage.out
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: sonarsource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8 # v5.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Closes #78

Fixes the repo-wide **`startup_failure`** — every CI run has ended at 0s with no jobs executed since ~2026-07-12, so lint/gosec/test/sonarcloud never ran (only CodeQL reported on PRs).

## WHY
The org enforces `sha_pinning_required = true` (GitHub Actions org policy). Every action reference in `CI.yaml` used a **tag** (`@v4`, `@v3`, `@master`), which the policy rejects at workflow startup — hence `startup_failure` before any job is created. (Confirmed root cause: even `github/super-linter/slim@v4`, which *is* on the org allow-list, was rejected — proving the blocker is pinning, not the allow-list.)

## WHAT
Pin **all 8 action references** to full commit SHAs, each with a version comment:

| Action | Pinned SHA (version) |
|---|---|
| `actions/checkout` | `34e1148…` (v4) |
| `actions/setup-go` | `be3c94b…` (v3) |
| `github/super-linter/slim` | `985ef20…` (v4) |
| `securego/gosec` | `9e6a984…` (v2.27.1) |
| `codecov/codecov-action` | `ab904c4…` (v3) |
| `actions/upload-artifact` | `ea165f8…` (v4) |
| `actions/download-artifact` | `d3f86a1…` (v4) |
| `sonarsource/sonarcloud-github-action` | `ffc3010…` (v5.0.0) |

## Companion infra PR (required)
`securego/gosec` is **not** on the org allowed-actions list (unlike the other actions, which are github-owned or already listed), so it also needs allow-listing:
- **shaharia-lab/infrastructure#310** — adds `securego/gosec@*` to `patterns_allowed`.

Both must merge (and the infra apply run) for CI to start. `actions/*` are covered by `github_owned_allowed = true`; `super-linter`, `codecov`, `sonarcloud` are already in `patterns_allowed` — they only needed SHA pinning.

## Acceptance criteria
- [x] No tag-based action refs remain (`grep` confirms all `@<sha>`).
- [x] `CI.yaml` parses as valid YAML / Actions structure; jobs unchanged.
- [ ] A push/PR reaches the jobs instead of `startup_failure` — **verifiable only after this + #310 merge** (CI cannot self-validate a startup fix pre-merge).

## Notes / out of scope
- Scope is **making CI start**. Individual job outcomes once it runs (e.g. lint/sonar failures, or that this repo's older action majors like `setup-go@v3`/`codecov@v3` emit deprecation warnings) are follow-ups, per #78.
- Overlaps PR #76 on the `gosec` job's `uses:` line (#76 converts it to `go run`). Whichever merges second needs a trivial rebase; the outcomes are compatible.
