### PR TITLE
fix: eliminate all data races in SSE/stdio servers + tests, enforce -race in CI (#79)

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -65,7 +65,7 @@ jobs:
           cache: true
 
       - name: Test
-        run: go test ./... -covermode=atomic -coverprofile=coverage.out
+        run: go test -race ./... -covermode=atomic -coverprofile=coverage.out
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/mcp_server_sse.go
+++ b/mcp_server_sse.go
@@ -476,9 +476,12 @@ func (s *SSEServer) Run(ctx context.Context) error {
 	// Shutdown handling
 	errChan := make(chan error, 1)
 	go func() {
-		if err = server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			s.logger.WithErr(err).Error("Error starting server")
-			errChan <- err
+		// Local error, not the outer err: this goroutine runs concurrently with
+		// the ctx.Done() branch (which writes err via server.Shutdown), so
+		// sharing err is a data race. Result is reported over errChan.
+		if serveErr := server.ListenAndServe(); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			s.logger.WithErr(serveErr).Error("Error starting server")
+			errChan <- serveErr
 		}
 	}()
 

--- a/mcp_server_sse_test.go
+++ b/mcp_server_sse_test.go
@@ -46,14 +46,18 @@ func TestHandleSSEConnection(t *testing.T) {
 	server := NewSSEServer(baseServer)
 
 	req := httptest.NewRequest("GET", "/events", nil)
-	w := httptest.NewRecorder()
+	w := newFlushSignalRecorder()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	req = req.WithContext(ctx)
 
 	go server.handleSSEConnection(ctx, w, req)
 
-	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-w.flushed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for SSE handler to write headers")
+	}
 
 	headers := w.Header()
 	if headers.Get("Content-Type") != "text/event-stream" {
@@ -453,14 +457,19 @@ func TestSSEConnectionFlow(t *testing.T) {
 
 	t.Run("Complete Connection Flow", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/events", nil)
-		w := httptest.NewRecorder()
+		sseW := newFlushSignalRecorder()
 		clientCtx, clientCancel := context.WithCancel(context.Background())
 		defer clientCancel()
 
-		go server.handleSSEConnection(context.Background(), w, req.WithContext(clientCtx))
-		time.Sleep(100 * time.Millisecond)
+		go server.handleSSEConnection(context.Background(), sseW, req.WithContext(clientCtx))
 
-		headers := w.Header()
+		select {
+		case <-sseW.flushed:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for SSE handler to write headers")
+		}
+
+		headers := sseW.Header()
 		require.Equal(t, "text/event-stream", headers.Get("Content-Type"))
 		require.Equal(t, "no-cache", headers.Get("Cache-Control"))
 
@@ -486,7 +495,7 @@ func TestSSEConnectionFlow(t *testing.T) {
 		require.NoError(t, err)
 
 		req = httptest.NewRequest("POST", "/message?clientID="+clientID, bytes.NewBuffer(payloadBytes))
-		w = httptest.NewRecorder()
+		w := httptest.NewRecorder()
 
 		server.handleClientMessage(context.Background(), w, req)
 		require.Equal(t, http.StatusOK, w.Code)
@@ -497,17 +506,24 @@ func TestSSEConnectionFlow(t *testing.T) {
 			Result  map[string]interface{} `json:"result"`
 		}
 
-		select {
-		case msg := <-server.clients[clientID]:
-			err := json.Unmarshal(msg, &initResponse)
-			require.NoError(t, err)
-			require.Equal(t, "2.0", initResponse.JsonRPC)
-			require.Equal(t, "1", initResponse.ID)
-			require.Contains(t, initResponse.Result, "serverInfo")
-			require.Contains(t, initResponse.Result, "capabilities")
-		case <-time.After(1 * time.Second):
-			t.Fatal("Timeout waiting for initialize response")
+		server.clientsMutex.RLock()
+		clientCh := server.clients[clientID]
+		server.clientsMutex.RUnlock()
+		// Drain to the initialize response (id "1"), skipping any unrelated
+		// notification-style messages that may be delivered first.
+		deadline := time.After(2 * time.Second)
+		for initResponse.ID != "1" {
+			select {
+			case msg := <-clientCh:
+				_ = json.Unmarshal(msg, &initResponse)
+			case <-deadline:
+				t.Fatal("Timeout waiting for initialize response")
+			}
 		}
+		require.Equal(t, "2.0", initResponse.JsonRPC)
+		require.Equal(t, "1", initResponse.ID)
+		require.Contains(t, initResponse.Result, "serverInfo")
+		require.Contains(t, initResponse.Result, "capabilities")
 	})
 
 	t.Run("Concurrent Connections", func(t *testing.T) {
@@ -541,4 +557,24 @@ func TestSSEConnectionFlow(t *testing.T) {
 
 		wgClients.Wait()
 	})
+}
+
+// flushSignalRecorder wraps httptest.ResponseRecorder and closes flushed on the
+// first Flush. Tests that run an SSE handler in a goroutine wait on flushed
+// before reading headers: the handler sets all headers before its first flush
+// and never touches them after, so the send/receive is a happens-before edge
+// that makes those reads race-free.
+type flushSignalRecorder struct {
+	*httptest.ResponseRecorder
+	flushed chan struct{}
+	once    sync.Once
+}
+
+func newFlushSignalRecorder() *flushSignalRecorder {
+	return &flushSignalRecorder{ResponseRecorder: httptest.NewRecorder(), flushed: make(chan struct{})}
+}
+
+func (r *flushSignalRecorder) Flush() {
+	r.once.Do(func() { close(r.flushed) })
+	r.ResponseRecorder.Flush()
 }

--- a/mcp_server_stdio.go
+++ b/mcp_server_stdio.go
@@ -152,7 +152,10 @@ func (s *StdIOServer) Run(ctx context.Context) error {
 				}
 
 				var request Request
-				if err = json.Unmarshal(raw, &request); err == nil && request.Method != "" && request.ID != nil {
+				// Local error, not the outer err: this goroutine runs
+				// concurrently with Run's deferred span handler (which reads
+				// err), so writing the shared err here is a data race.
+				if reqErr := json.Unmarshal(raw, &request); reqErr == nil && request.Method != "" && request.ID != nil {
 					if request.Method != "initialize" && !initialized {
 						s.logger.Error("Received request before 'initialize'")
 						s.sendError("", request.ID, -32000, "Server not initialized", nil) // Empty clientID

--- a/mcp_server_stdio_test.go
+++ b/mcp_server_stdio_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Test helper to wait for and parse response
-func waitForResponse(t *testing.T, out *bytes.Buffer, timeout time.Duration) *Response {
+func waitForResponse(t *testing.T, out *syncBuffer, timeout time.Duration) *Response {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		if out.Len() > 0 {
@@ -631,7 +631,7 @@ func TestHandlePromptGet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			inR, inW := io.Pipe()
-			out := &bytes.Buffer{}
+			out := &syncBuffer{}
 
 			codeReviewPrompt := Prompt{
 				Name:        "code_review",
@@ -733,21 +733,40 @@ func (b *syncBuffer) ReadAll() []byte {
 	return data
 }
 
+func (b *syncBuffer) Len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buffer.Len()
+}
+
+func (b *syncBuffer) Bytes() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]byte(nil), b.buffer.Bytes()...)
+}
+
+func (b *syncBuffer) Reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buffer.Reset()
+}
+
 func TestSuccessfulConnectionEstablishedFlow(t *testing.T) {
 	baseServer, err := NewBaseServer(UseLogger(NewNullLogger()))
 	require.NoError(t, err)
 
-	in := &syncBuffer{}
+	inR, inW := io.Pipe()
 	out := &syncBuffer{}
-	server := NewStdIOServer(baseServer, in, out)
+	server := NewStdIOServer(baseServer, inR, out)
 	require.NotNil(t, server)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	go func() {
-		err := server.Run(ctx)
-		require.NoError(t, err)
+		if err := server.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+			t.Errorf("unexpected server error: %v", err)
+		}
 	}()
 
 	waitForResponse := func(t *testing.T, output *syncBuffer, timeout time.Duration) *Response {
@@ -773,7 +792,7 @@ func TestSuccessfulConnectionEstablishedFlow(t *testing.T) {
 
 	t.Run("Initialization Flow", func(t *testing.T) {
 		initializeRequest := `{"jsonrpc":"2.0","id":"1","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}`
-		_, err := in.Write([]byte(initializeRequest + "\n"))
+		_, err := inW.Write([]byte(initializeRequest + "\n"))
 		require.NoError(t, err)
 
 		initResponse := waitForResponse(t, out, 1*time.Second)
@@ -786,14 +805,14 @@ func TestSuccessfulConnectionEstablishedFlow(t *testing.T) {
 		require.Contains(t, serverInfo, "serverInfo")
 		require.Contains(t, serverInfo, "capabilities")
 
-		_, err = in.Write([]byte(`{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n"))
+		_, err = inW.Write([]byte(`{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n"))
 		require.NoError(t, err)
 		time.Sleep(100 * time.Millisecond)
 	})
 
 	t.Run("Notification Handling", func(t *testing.T) {
 		notificationRequest := `{"jsonrpc":"2.0","method":"notifications/test-notification"}`
-		_, err := in.Write([]byte(notificationRequest + "\n"))
+		_, err := inW.Write([]byte(notificationRequest + "\n"))
 		require.NoError(t, err)
 
 		// Notifications don't return a direct response; ensure no errors occurred


### PR DESCRIPTION
Closes #79 (supersedes #82, which auto-closed when #80's base branch was deleted)

Makes `go test -race ./...` clean (0 failures over 20+ full-module runs, 40× per-test) and adds `-race` to the CI test job.

## Production concurrency bugs fixed
- **`SSEServer.Run`** — `ListenAndServe` goroutine wrote shared `err` racing the `ctx.Done()`→`Shutdown` branch; now uses a local error.
- **`StdIOServer.Run`** — reader goroutine wrote shared `err` (read by the deferred span handler); now uses a local error.

## Test races (masked by `time.Sleep`, exposed under -race)
- SSE: `flushSignalRecorder` happens-before edge before reading handler-written headers; init read captures the channel under `clientsMutex` and drains to the response `id` (fixes intermittent empty-`id`).
- stdio: `syncBuffer` gains `Len`/`Bytes`/`Reset` (`TestHandlePromptGet`); `TestSuccessfulConnectionEstablishedFlow` uses an `io.Pipe` input (blocking reads) and tolerates `context.Canceled`.

Rebased onto current `main` (post-#80). Verified: `go test -race ./...` 0/3 after rebase, build/vet clean.